### PR TITLE
Increased seed limit to 2^32 - 1 (4,294,967,295)

### DIFF
--- a/src/interfaces/comfyui_node.py
+++ b/src/interfaces/comfyui_node.py
@@ -68,7 +68,7 @@ class SeedVR2:
                 "seed": ("INT", {
                     "default": 100, 
                     "min": 0, 
-                    "max": 5000, 
+                    "max": 2**32 - 1, 
                     "step": 1,
                     "tooltip": "Random seed for generation reproducibility"
                 }),


### PR DESCRIPTION
Limited by NumPy's 32-bit seed number generator.

To address https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler/issues/54