### PR TITLE
patch for other diffusers version : version breakage

### DIFF
--- a/src/models/video_vae_v3/modules/attn_video_vae.py
+++ b/src/models/video_vae_v3/modules/attn_video_vae.py
@@ -23,7 +23,7 @@ from diffusers.models.downsampling import Downsample2D
 from diffusers.models.lora import LoRACompatibleConv
 from diffusers.models.modeling_outputs import AutoencoderKLOutput
 from diffusers.models.resnet import ResnetBlock2D
-from diffusers.models.unets.unet_2d_blocks import DownEncoderBlock2D, UpDecoderBlock2D
+from diffusers.models.unet_2d_blocks import DownEncoderBlock2D, UpDecoderBlock2D
 from diffusers.models.upsampling import Upsample2D
 from diffusers.utils import is_torch_version
 from diffusers.utils.accelerate_utils import apply_forward_hook

--- a/src/models/video_vae_v3_mine_bad/modules/attn_video_vae.py
+++ b/src/models/video_vae_v3_mine_bad/modules/attn_video_vae.py
@@ -22,7 +22,7 @@ from diffusers.models.downsampling import Downsample2D
 from diffusers.models.lora import LoRACompatibleConv
 from diffusers.models.modeling_outputs import AutoencoderKLOutput
 from diffusers.models.resnet import ResnetBlock2D
-from diffusers.models.unets.unet_2d_blocks import DownEncoderBlock2D, UpDecoderBlock2D
+from diffusers.models.unet_2d_blocks import DownEncoderBlock2D, UpDecoderBlock2D
 from diffusers.models.upsampling import Upsample2D
 from diffusers.utils import is_torch_version
 from diffusers.utils.accelerate_utils import apply_forward_hook


### PR DESCRIPTION
This is most likely a breaking change for other versions of diffusers. So I'd recommend you just hold this as a reference. You can point to this patch as a temp work around for people running 0.25.0 diffusers. 