### PR TITLE
Defaulting to latest diffusers version or higher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 einops                   # Tensor operations
 omegaconf>=2.3.0                # Configuration system.
-diffusers               # Diffusers
+diffusers>=0.34.0                # Diffusers
 pytorch-extension #pytorch extension
 rotary_embedding_torch
 opencv-python

--- a/src/utils/downloads.py
+++ b/src/utils/downloads.py
@@ -1,6 +1,6 @@
 """
 Downloads utility module for SeedVR2
-Handles model and VAE downloads from HuggingFace Hub
+Handles model and VAE downloads from HuggingFace
 
 Extracted from: seedvr2.py (line 968-1015)
 """


### PR DESCRIPTION
This is to fix the error :
`Could not import 'NaDiT' from any of the paths: ['custom_nodes.ComfyUI-SeedVR2_VideoUpscaler.src.models.dit.nadit', 'ComfyUI.custom_nodes.ComfyUI-SeedVR2_VideoUpscaler.src.models.dit.nadit', 'src.models.dit.nadit']. Last error: cannot import name 'cached_download' from 'huggingface_hub' (C:\Users\olivi\Documents\ComfyUI.venv\Lib\site-packages\huggingface_hub_init_.py)`
https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler/issues/75

Even if we are not using huggingface_hub in the code anymore, if the user has an incompatible version installed on their machine, it will clash with diffusers. Forcing the latest version of diffusers should force the matching updated version of huggingface_hub (if installed) and avoid the issue.