### PR TITLE
Models update - FP8, GGUF, Artifacts

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -37,11 +37,16 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 '''
 # Progressive import system with fallback
+# ===== MODULE 0: Constants =====
+if MODULES_AVAILABLE['downloads']:
+    from src.utils.constants import (
+        get_base_cache_dir,
+    )
+
 # ===== MODULE 1: Downloads =====
 if MODULES_AVAILABLE['downloads']:
     from src.utils.downloads import (
         download_weight,
-        get_base_cache_dir
     )
     
 
@@ -111,8 +116,11 @@ if MODULES_AVAILABLE['comfyui_node']:
 
 # Export all available functions
 __all__ = [
+    # Constants
+    'get_base_cache_dir',
+
     # Utils
-    'download_weight', 'get_base_cache_dir',
+    'download_weight', 
     
     # Memory Management
     'get_vram_usage', 'clear_vram_cache', 'reset_vram_peak', 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -70,8 +70,6 @@ if MODULES_AVAILABLE['performance']:
 if MODULES_AVAILABLE['compatibility']:
     from src.optimization.compatibility import (
         FP8CompatibleDiT,
-        apply_fp8_compatibility_hooks,
-        remove_compatibility_hooks,
     )
     
 
@@ -126,7 +124,7 @@ __all__ = [
     'validate_video_format', 'ensure_4n_plus_1_format', 'calculate_padding_requirements', 'apply_wavelet_reconstruction', 'temporal_consistency_check',
     
     # Compatibility
-    'FP8CompatibleDiT', 'apply_fp8_compatibility_hooks', 'remove_compatibility_hooks',
+    'FP8CompatibleDiT',
     
     # Core Model & Generation & Infer
     'configure_runner', 'load_quantized_state_dict', 'configure_dit_model_inference', 'configure_vae_model_inference',

--- a/src/core/generation.py
+++ b/src/core/generation.py
@@ -20,6 +20,7 @@ import os
 import gc
 import torch
 import time
+from src.utils.constants import get_script_directory
 from torchvision.transforms import Compose, Lambda, Normalize
 
 
@@ -37,7 +38,7 @@ except:
     COMFYUI_AVAILABLE = False
     pass
 # Get script directory for embeddings
-script_directory = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+script_directory = get_script_directory()
 
 # Import transforms and color fix
 

--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -18,6 +18,7 @@ Key Features:
 import os
 import time
 import torch
+from src.utils.constants import get_script_directory
 from omegaconf import DictConfig, OmegaConf
 
 # Import SafeTensors with fallback
@@ -36,7 +37,7 @@ from src.core.infer import VideoDiffusionInfer
 from src.optimization.blockswap import apply_block_swap_to_dit
 
 # Get script directory for config paths
-script_directory = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+script_directory = get_script_directory()
 
 
 def configure_runner(model, base_cache_dir, preserve_vram=False, debug=False, block_swap_config=None, cached_runner=None):

--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -205,61 +205,6 @@ def configure_runner(model, base_cache_dir, preserve_vram=False, debug=False, bl
     # Apply BlockSwap if configured
     if blockswap_active:
         apply_block_swap_to_dit(runner, block_swap_config)
-    else:
-        # === ADD THIS LOGGING CODE HERE ===
-        print("[DEBUG] Running WITHOUT blockswap - direct model execution")
-        
-        # Check if model has mixed precision
-        try:
-            # Get the actual model (handle FP8CompatibleDiT wrapper)
-            actual_model = runner.dit
-            if hasattr(actual_model, 'dit_model'):
-                actual_model = actual_model.dit_model
-                
-            if hasattr(actual_model, 'blocks'):
-                blocks = actual_model.blocks
-                block_dtypes = []
-                
-                # Analyze each block's dtype
-                for i, block in enumerate(blocks):
-                    try:
-                        block_dtype = next(block.parameters()).dtype
-                        block_dtypes.append((i, str(block_dtype)))
-                        
-                        # Special attention to last block
-                        if i == len(blocks) - 1:
-                            print(f"[DEBUG] Block {i} (LAST): dtype={block_dtype}")
-                            if block_dtype == torch.float16:
-                                print(f"[DEBUG] ⚠️ Last block is FP16 - potential mixed precision boundary")
-                            
-                            # Check all parameters in last block
-                            param_dtypes = set()
-                            for name, param in block.named_parameters():
-                                param_dtypes.add(str(param.dtype))
-                            if len(param_dtypes) > 1:
-                                print(f"[DEBUG] ⚠️ Last block has mixed dtypes: {param_dtypes}")
-                    except Exception as e:
-                        print(f"[DEBUG] Could not analyze block {i}: {e}")
-                
-                # Print dtype distribution
-                dtype_counts = {}
-                for idx, dtype_str in block_dtypes:
-                    dtype_counts[dtype_str] = dtype_counts.get(dtype_str, 0) + 1
-                
-                print(f"[DEBUG] Block dtype distribution: {dtype_counts}")
-                print(f"[DEBUG] Total blocks: {len(blocks)}")
-                
-                # Check for FP8/FP16 boundary
-                if len(block_dtypes) > 1:
-                    last_dtype = block_dtypes[-1][1]
-                    second_last_dtype = block_dtypes[-2][1] if len(block_dtypes) > 1 else None
-                    
-                    if 'float8' in str(second_last_dtype) and 'float16' in str(last_dtype):
-                        print(f"[DEBUG] ⚠️ MIXED PRECISION DETECTED: Blocks 0-{len(blocks)-2} are {second_last_dtype}, Block {len(blocks)-1} is {last_dtype}")
-                        print(f"[DEBUG] This mixed precision boundary may cause artifacts without blockswap!")
-                        
-        except Exception as e:
-            print(f"[DEBUG] Could not analyze model structure: {e}")
     #clear_vram_cache()
     return runner
 

--- a/src/interfaces/comfyui_node.py
+++ b/src/interfaces/comfyui_node.py
@@ -7,7 +7,10 @@ import time
 import torch
 from typing import Tuple, Dict, Any
 
-from src.utils.downloads import download_weight, get_base_cache_dir
+from src.utils.constants import get_base_cache_dir
+from src.utils.downloads import download_weight
+from src.utils.model_registry import get_available_models, DEFAULT_MODEL
+from src.utils.constants import get_script_directory
 from src.core.model_manager import configure_runner
 from src.core.generation import generation_loop
 from src.optimization.memory_manager import fast_model_cleanup, fast_ram_cleanup
@@ -22,7 +25,7 @@ from src.optimization.memory_manager import (
 # Import ComfyUI progress reporting
 from server import PromptServer
 
-script_directory = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+script_directory = get_script_directory()
 
 class SeedVR2:
     """
@@ -53,17 +56,11 @@ class SeedVR2:
             Dictionary defining input parameters, types, and validation
         """
         return {
-            "required": {
+                "required": {
                 "images": ("IMAGE", ),
-                "model": ([
-                    "seedvr2_ema_3b_fp16.safetensors", 
-                    "seedvr2_ema_3b_fp8_e4m3fn.safetensors",
-                    "seedvr2_ema_7b_fp16.safetensors",
-                    "seedvr2_ema_7b_fp8_e4m3fn.safetensors",
-                    "seedvr2_ema_7b_sharp_fp16.safetensors",
-                    "seedvr2_ema_7b_sharp_fp8_e4m3fn.safetensors"
-                ], {
-                    "default": "seedvr2_ema_3b_fp8_e4m3fn.safetensors"
+                "model": (get_available_models(), {
+                    "default": DEFAULT_MODEL,
+                    "tooltip": "Model variants with different sizes and precisions. Models will automatically download on first use. Additional models can be added to the ComfyUI models folder."
                 }),
                 "seed": ("INT", {
                     "default": 100, 

--- a/src/models/dit/nablocks/mmsr_block.py
+++ b/src/models/dit/nablocks/mmsr_block.py
@@ -222,18 +222,6 @@ class NaMMSRTransformerBlock(MMWindowTransformerBlock):
         torch.LongTensor,
         torch.LongTensor,
     ]:
-        # === ADD DEBUG LOGGING FOR NON-BLOCKSWAP CASE ===
-        if hasattr(self, '_block_idx') and not hasattr(self, '_blockswap_wrapped'):
-            # This means we're not using blockswap
-            is_last_block = hasattr(self, 'is_last_layer') and self.is_last_layer
-            if is_last_block:
-                print(f"[NON-BLOCKSWAP] Last block forward: vid.dtype={vid.dtype}, device={vid.device}")
-                # Check parameter dtypes
-                param_dtypes = set()
-                for param in self.parameters():
-                    param_dtypes.add(str(param.dtype))
-                print(f"[NON-BLOCKSWAP] Last block param dtypes: {param_dtypes}")
-                
         hid_len = MMArg(
             cache("vid_len", lambda: vid_shape.prod(-1)),
             cache("txt_len", lambda: txt_shape.prod(-1)),

--- a/src/models/dit/nablocks/mmsr_block.py
+++ b/src/models/dit/nablocks/mmsr_block.py
@@ -222,6 +222,18 @@ class NaMMSRTransformerBlock(MMWindowTransformerBlock):
         torch.LongTensor,
         torch.LongTensor,
     ]:
+        # === ADD DEBUG LOGGING FOR NON-BLOCKSWAP CASE ===
+        if hasattr(self, '_block_idx') and not hasattr(self, '_blockswap_wrapped'):
+            # This means we're not using blockswap
+            is_last_block = hasattr(self, 'is_last_layer') and self.is_last_layer
+            if is_last_block:
+                print(f"[NON-BLOCKSWAP] Last block forward: vid.dtype={vid.dtype}, device={vid.device}")
+                # Check parameter dtypes
+                param_dtypes = set()
+                for param in self.parameters():
+                    param_dtypes.add(str(param.dtype))
+                print(f"[NON-BLOCKSWAP] Last block param dtypes: {param_dtypes}")
+                
         hid_len = MMArg(
             cache("vid_len", lambda: vid_shape.prod(-1)),
             cache("txt_len", lambda: txt_shape.prod(-1)),

--- a/src/models/dit/normalization.py
+++ b/src/models/dit/normalization.py
@@ -86,6 +86,13 @@ class CustomRMSNorm(nn.Module):
         normalized = input / rms
         
         if self.elementwise_affine:
+            # Convert FP8 weight to BFloat16 for arithmetic operations
+            if hasattr(torch, 'float8_e4m3fn'):
+                fp8_types = (torch.float8_e4m3fn, torch.float8_e5m2)
+                if self.weight.dtype in fp8_types:
+                    weight = self.weight.to(torch.bfloat16)
+                    return normalized * weight
+                    
             return normalized * self.weight
         return normalized
 

--- a/src/models/dit_v2/modulation.py
+++ b/src/models/dit_v2/modulation.py
@@ -92,25 +92,26 @@ class AdaSingle(nn.Module):
             getattr(self, f"{layer}_gate", None),
         )
 
-        # 🚀 FP8 COMPATIBILITY: Convert parameters to match embedding dtype
-        # This prevents "Promotion for Float8 Types is not supported" errors
-        target_dtype = shiftA.dtype
-        
+        # Handle potential FP8 parameters - convert to computation dtype
+        if hasattr(torch, 'float8_e4m3fn'):
+            fp8_types = (torch.float8_e4m3fn, torch.float8_e5m2)
+            
+            # Convert FP8 parameters to BFloat16 for arithmetic operations
+            if shiftB is not None and shiftB.dtype in fp8_types:
+                shiftB = shiftB.to(torch.bfloat16)
+            if scaleB is not None and scaleB.dtype in fp8_types:
+                scaleB = scaleB.to(torch.bfloat16)
+            if gateB is not None and gateB.dtype in fp8_types:
+                gateB = gateB.to(torch.bfloat16)
+
         if mode == "in":
-            # Convert parameters to match embedding dtype for FP8 compatibility
-            if scaleB is not None and scaleB.dtype != target_dtype:
-                scaleB = scaleB.to(target_dtype)
-            if shiftB is not None and shiftB.dtype != target_dtype:
-                shiftB = shiftB.to(target_dtype)
-            
             return hid.mul_(scaleA + scaleB).add_(shiftA + shiftB)
-            
         if mode == "out":
-            # Convert gate parameter to match embedding dtype for FP8 compatibility
-            if gateB is not None and gateB.dtype != target_dtype:
-                gateB = gateB.to(target_dtype)
-            
-            return hid.mul_(gateA + gateB)
+            if gateB is not None:
+                return hid.mul_(gateA + gateB)
+            else:
+                # If no gate parameter, just use the embedding gate
+                return hid.mul_(gateA)
             
         raise NotImplementedError
 

--- a/src/optimization/__init__.py
+++ b/src/optimization/__init__.py
@@ -23,8 +23,6 @@ from .performance import (
 # Compatibility functions and classes
 from .compatibility import (
     FP8CompatibleDiT,
-    apply_fp8_compatibility_hooks,
-    remove_compatibility_hooks,
 )
 
 __all__ = [
@@ -43,7 +41,5 @@ __all__ = [
     
     # Compatibility
     "FP8CompatibleDiT",
-    "apply_fp8_compatibility_hooks",
-    "remove_compatibility_hooks",
 ] 
 '''

--- a/src/optimization/blockswap.py
+++ b/src/optimization/blockswap.py
@@ -351,137 +351,22 @@ def _wrap_block_forward(block: torch.nn.Module, block_idx: int, model: torch.nn.
         if hasattr(model, 'blocks_to_swap') and self._block_idx <= model.blocks_to_swap:
             t_start = time.time() if debugger and debugger.enabled else None
 
-            # === ENHANCED DEBUG LOGGING ===
-            # Check if this is the last block
-            try:
-                total_blocks = len(model.blocks) if hasattr(model, 'blocks') else 0
-                is_last_block = self._block_idx == total_blocks - 1
-            except:
-                is_last_block = False
-            
-            # Log input tensor info - FIXED to handle actual inputs
-            if debugger and debugger.enabled:
-                input_info = []
-                
-                # Log all tensor arguments
-                for i, arg in enumerate(args):
-                    if isinstance(arg, torch.Tensor):
-                        input_info.append(f"arg[{i}]: dtype={arg.dtype}, device={arg.device}, shape={arg.shape}")
-                        
-                        # For last block, log sample values and statistics
-                        if is_last_block and i < 2:  # Only for vid and txt tensors
-                            with torch.no_grad():
-                                try:
-                                    # Get sample values
-                                    sample_vals = arg.flatten()[:5].tolist()
-                                    debugger.log(f"[Block {self._block_idx}] Input[{i}] sample values: {sample_vals}")
-                                    
-                                    # Get statistics
-                                    arg_float = arg.float()
-                                    mean_val = arg_float.mean().item()
-                                    std_val = arg_float.std().item()
-                                    min_val = arg_float.min().item()
-                                    max_val = arg_float.max().item()
-                                    debugger.log(f"[Block {self._block_idx}] Input[{i}] stats: mean={mean_val:.6f}, std={std_val:.6f}, min={min_val:.6f}, max={max_val:.6f}")
-                                    
-                                    # Check for anomalies
-                                    if abs(mean_val) > 10 or std_val > 100 or abs(min_val) > 1000 or abs(max_val) > 1000:
-                                        debugger.log(f"[Block {self._block_idx}] ⚠️ Input[{i}] has abnormal values!")
-                                except Exception as e:
-                                    debugger.log(f"[Block {self._block_idx}] Could not compute input[{i}] statistics: {e}")
-                
-                # Also log kwargs if any contain tensors
-                for key, value in kwargs.items():
-                    if isinstance(value, torch.Tensor):
-                        input_info.append(f"kwarg[{key}]: dtype={value.dtype}, device={value.device}, shape={value.shape}")
-                
-                if input_info:
-                    debugger.log(f"[Block {self._block_idx}] {'LAST BLOCK (FP16)' if is_last_block else 'FP8'} Pre-swap inputs: {input_info}")
-                else:
-                    debugger.log(f"[Block {self._block_idx}] {'LAST BLOCK (FP16)' if is_last_block else 'FP8'} Pre-swap: No tensor inputs found in {len(args)} args")
-                    
-                # Log block parameter dtypes
-                param_dtypes = set()
-                for param in self.parameters():
-                    param_dtypes.add(str(param.dtype))
-                debugger.log(f"[Block {self._block_idx}] Block param dtypes: {param_dtypes}")
-
             # Only move to GPU if necessary
             current_device = next(self.parameters()).device
             target_device = torch.device(model.main_device)
             
             if current_device != target_device:
-                # Log before .to() operation
-                if debugger and debugger.enabled:
-                    debugger.log(f"[Block {self._block_idx}] Moving from {current_device} to {target_device}")
-                    
                 self.to(model.main_device, non_blocking=model.use_non_blocking)
                 
-                # Log after .to() operation
-                if debugger and debugger.enabled:
-                    # Check if dtypes changed
-                    new_param_dtypes = set()
-                    for param in self.parameters():
-                        new_param_dtypes.add(str(param.dtype))
-                    if new_param_dtypes != param_dtypes:
-                        debugger.log(f"[Block {self._block_idx}] WARNING: DTYPE CHANGE after .to(): {param_dtypes} -> {new_param_dtypes}")
-                    
             # Synchronize if needed
             if hasattr(model, 'use_non_blocking') and not model.use_non_blocking:
                 torch.cuda.synchronize()
 
             # Execute forward pass with OOM protection
-            try:
-                output = original_forward(*args, **kwargs)
-            except Exception as e:
-                debugger.log(f"[Block {self._block_idx}] ERROR in forward: {e}")
-                raise
-            
-            # === ENHANCED OUTPUT LOGGING ===
-            if debugger and debugger.enabled:
-                # Handle different output types (tuple or single tensor)
-                output_tensors = []
-                if isinstance(output, tuple):
-                    for i, out in enumerate(output):
-                        if isinstance(out, torch.Tensor):
-                            output_tensors.append((i, out))
-                elif isinstance(output, torch.Tensor):
-                    output_tensors.append((0, output))
-                
-                for idx, out_tensor in output_tensors:
-                    debugger.log(f"[Block {self._block_idx}] Output[{idx}]: dtype={out_tensor.dtype}, device={out_tensor.device}, shape={out_tensor.shape}")
-                    
-                    # Detailed analysis for last block
-                    if is_last_block:
-                        with torch.no_grad():
-                            has_nan = torch.isnan(out_tensor).any().item()
-                            has_inf = torch.isinf(out_tensor).any().item()
-                            
-                            if has_nan or has_inf:
-                                debugger.log(f"[Block {self._block_idx}] ⚠️ WARNING: Output has NaN={has_nan}, Inf={has_inf}")
-                                
-                            # Compute statistics
-                            try:
-                                out_float = out_tensor.float()
-                                mean_val = out_float.mean().item()
-                                std_val = out_float.std().item()
-                                min_val = out_float.min().item()
-                                max_val = out_float.max().item()
-                                
-                                debugger.log(f"[Block {self._block_idx}] Output stats: mean={mean_val:.6f}, std={std_val:.6f}, min={min_val:.6f}, max={max_val:.6f}")
-                                
-                                # Check for artifact indicators
-                                if abs(mean_val) > 10 or std_val > 100 or abs(min_val) > 1000 or abs(max_val) > 1000:
-                                    debugger.log(f"[Block {self._block_idx}] ⚠️ ABNORMAL VALUES DETECTED - potential artifacts!")
-                            except:
-                                debugger.log(f"[Block {self._block_idx}] Could not compute output statistics")
+            output = original_forward(*args, **kwargs)
 
             # Move back to offload device
             self.to(model.offload_device, non_blocking=model.use_non_blocking)
-            
-            # === LOG POST-OFFLOAD STATE ===
-            if debugger and debugger.enabled:
-                debugger.log(f"[Block {self._block_idx}] Post-offload complete")
             
             # Log timing if debugger is available
             if debugger and t_start is not None:
@@ -496,9 +381,6 @@ def _wrap_block_forward(block: torch.nn.Module, block_idx: int, model: torch.nn.
             if torch.cuda.memory_allocated() > torch.cuda.get_device_properties(0).total_memory * 0.9:
                 mm.soft_empty_cache()
         else:
-            # === LOG NON-SWAPPED BLOCKS ===
-            if debugger and debugger.enabled and self._block_idx % 10 == 0:  # Log every 10th non-swapped block
-                debugger.log(f"[Block {self._block_idx}] Running without swap (block > blocks_to_swap)")
             output = original_forward(*args, **kwargs)
 
         return output

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -5,7 +5,6 @@ Contains FP8/FP16 compatibility layers and wrappers for different model architec
 Extracted from: seedvr2.py (lines 1045-1630)
 """
 
-import time
 import torch
 from typing import List, Tuple, Union, Any, Optional
 
@@ -15,7 +14,7 @@ class FP8CompatibleDiT(torch.nn.Module):
     Wrapper for DiT models with automatic compatibility management + advanced optimizations
     - FP8: Keeps native FP8 parameters, converts inputs/outputs
     - FP16: Uses native FP16
-    - RoPE: ALWAYS forced to BFloat16 for maximum compatibility
+    - RoPE: Converted from FP8 to BFloat16 only when detected as FP8
     - Flash Attention: Automatic optimization of attention layers
     """
     
@@ -27,26 +26,14 @@ class FP8CompatibleDiT(torch.nn.Module):
         self.is_fp16_model = self.model_dtype == torch.float16
         
         # Only convert if not already done (e.g., when reusing cached weights)
-        if not skip_conversion:
-            # Detect model type
-            is_nadit_7b = self._is_nadit_model()      # NaDiT 7B (dit/nadit)
-            is_nadit_v2_3b = self._is_nadit_v2_model()  # NaDiT v2 3B (dit_v2/nadit)
+        if not skip_conversion and self.is_fp8_model:
+            # Only FP8 models need RoPE frequency conversion
+            # FP16 and BFloat16 models work as-is without conversion
+            model_variant = "7B" if self._is_nadit_model() else "3B" if self._is_nadit_v2_model() else "Unknown"
+            print(f"🎯 Detected NaDiT {model_variant} FP8 - Converting RoPE freqs for FP8 compatibility")
+            self._convert_rope_freqs()
             
-            if is_nadit_7b:
-                # 🎯 CRITICAL FIX: ALL NaDiT 7B models (FP8 AND FP16) require BFloat16 conversion
-                # 7B architecture has dtype compatibility issues regardless of storage format
-                if self.is_fp8_model:
-                    print("🎯 Detected NaDiT 7B FP8 - Converting all parameters to BFloat16")
-                    self._force_nadit_bfloat16()
-                else:
-                    print("🎯 Detected NaDiT 7B FP16")
-                
-                
-            elif self.is_fp8_model and is_nadit_v2_3b:
-                # For NaDiT v2 3B FP8: Convert ALL model to BFloat16
-                print("🎯 Detected NaDiT v2 3B FP8 - Converting all parameters to BFloat16")
-                self._force_nadit_bfloat16()
-        
+                      
         # 🚀 FLASH ATTENTION OPTIMIZATION (Phase 2)
         self._apply_flash_attention_optimization()
     
@@ -59,80 +46,27 @@ class FP8CompatibleDiT(torch.nn.Module):
     
     def _is_nadit_model(self) -> bool:
         """Detect if this is a NaDiT model (7B) with precise logic"""
-        # 🎯 PRIMARY METHOD: Check emb_scale attribute (specific to 7B)
-        # This is the most reliable criterion to distinguish 7B vs 3B
-        if hasattr(self.dit_model, 'emb_scale'):
-            return True
-        
-        # 🎯 SECONDARY METHOD: Check module path for NaDiT 7B (dit/nadit, not dit_v2)
+        # Check module path for dit (not dit_v2) 
         model_module = str(self.dit_model.__class__.__module__).lower()
-        if 'dit.nadit' in model_module and 'dit_v2' not in model_module:
-            return True
-        
-        return False
-    
+        return 'dit.nadit' in model_module and 'dit_v2' not in model_module
+
     def _is_nadit_v2_model(self) -> bool:
         """Detect if this is a NaDiT v2 model (3B) with precise logic"""
-        # 🎯 PRIMARY METHOD: Check module path for NaDiT v2 (dit_v2/nadit)
+        # Check module path for dit_v2
         model_module = str(self.dit_model.__class__.__module__).lower()
-        if 'dit_v2' in model_module:
-            return True
+        return 'dit_v2' in model_module
         
-        # 🎯 SECONDARY METHOD: Check specific 3B structure
-        # NaDiT v2 3B has vid_in, txt_in, emb_in but NO emb_scale
-        if (hasattr(self.dit_model, 'vid_in') and 
-            hasattr(self.dit_model, 'txt_in') and 
-            hasattr(self.dit_model, 'emb_in') and
-            not hasattr(self.dit_model, 'emb_scale')):  # Absence of emb_scale = 3B
-            return True
-        
-        return False
-    
-    def _force_rope_bfloat16(self) -> None:
-        """🎯 Force ALL RoPE modules to BFloat16 for maximum compatibility"""
-        rope_count = 0
-        for name, module in self.dit_model.named_modules():
-            # Identify RoPE modules by name or type
-            if any(keyword in name.lower() for keyword in ['rope', 'rotary', 'embedding']):
-                # Convert all parameters of this module to BFloat16
-                for param_name, param in module.named_parameters():
-                    if param.dtype != torch.bfloat16:
-                        param.data = param.data.to(torch.bfloat16)
-                        rope_count += 1
-                        
-                # Also convert buffers (non-trainable parameters)
-                for buffer_name, buffer in module.named_buffers():
-                    if buffer.dtype != torch.bfloat16:
-                        buffer.data = buffer.data.to(torch.bfloat16)
-                        rope_count += 1
-    
-    def _force_nadit_bfloat16(self) -> None:
-        """🎯 Force ALL NaDiT parameters to BFloat16 to avoid promotion errors"""
-        print("🔧 Converting ALL NaDiT parameters to BFloat16 for type compatibility...")
-        t = time.time()
-        converted_count = 0
-        original_dtype = None
-        
-        # Convert ALL parameters to BFloat16 (FP8, FP16, etc.)
-        for name, param in self.dit_model.named_parameters():
-            if original_dtype is None:
-                original_dtype = param.dtype
-            if param.dtype != torch.bfloat16:
-                param.data = param.data.to(torch.bfloat16)
-                converted_count += 1
-        
-        # Also convert buffers
-        for name, buffer in self.dit_model.named_buffers():
-            if buffer.dtype != torch.bfloat16:
-                buffer.data = buffer.data.to(torch.bfloat16)
-                converted_count += 1
-        
-        print(f"   ✅ Converted {converted_count} parameters/buffers from {original_dtype} to BFloat16")
-        
-        # Update detected dtype
-        self.model_dtype = torch.bfloat16
-        self.is_fp8_model = False  # Model is no longer FP8 after conversion
-    
+    def _convert_rope_freqs(self) -> None:
+        """Convert RoPE frequency buffers for FP8 compatibility"""
+        converted = 0
+        for module in self.dit_model.modules():
+            if 'RotaryEmbedding' in type(module).__name__:
+                if hasattr(module, 'rope') and hasattr(module.rope, 'freqs'):
+                    if module.rope.freqs.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+                        module.rope.freqs.data = module.rope.freqs.to(torch.bfloat16)
+                        converted += 1
+        print(f"   ✅ Converted {converted} RoPE frequency buffers")
+            
     def _apply_flash_attention_optimization(self) -> None:
         """🚀 FLASH ATTENTION OPTIMIZATION - 30-50% speedup of attention layers"""
         attention_layers_optimized = 0
@@ -330,81 +264,46 @@ class FP8CompatibleDiT(torch.nn.Module):
             return module._original_forward(x, *args, **kwargs)
     
     def forward(self, *args, **kwargs):
-        """Forward pass with intelligent type management according to architecture"""
-        is_nadit_7b = self._is_nadit_model()
-        is_nadit_v2_3b = self._is_nadit_v2_model()
+        """Forward pass with minimal dtype conversion overhead
         
-        # Input conversion according to architecture
-        if is_nadit_7b or is_nadit_v2_3b:
-            # For NaDiT models (7B and v2 3B): Everything to BFloat16
+        Conversion strategy:
+        - FP16 models: Keep everything in FP16 (no conversion needed)
+        - FP8 models: Convert FP8 tensors to BFloat16 (required for arithmetic)
+        - BFloat16 models: No conversion needed
+        """
+        
+        # Only convert if we have an FP8 model for arithmetic operations 
+        if self.is_fp8_model:
+            fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+            
+            # Convert args
             converted_args = []
             for arg in args:
-                if isinstance(arg, torch.Tensor):
-                    if arg.dtype in (torch.float32, torch.float8_e4m3fn, torch.float8_e5m2):
-                        converted_args.append(arg.to(torch.bfloat16))
-                    else:
-                        converted_args.append(arg)
+                if isinstance(arg, torch.Tensor) and arg.dtype in fp8_dtypes:
+                    converted_args.append(arg.to(torch.bfloat16))
                 else:
                     converted_args.append(arg)
             
+            # Convert kwargs
             converted_kwargs = {}
             for key, value in kwargs.items():
-                if isinstance(value, torch.Tensor):
-                    if value.dtype in (torch.float32, torch.float8_e4m3fn, torch.float8_e5m2):
-                        converted_kwargs[key] = value.to(torch.bfloat16)
-                    else:
-                        converted_kwargs[key] = value
+                if isinstance(value, torch.Tensor) and value.dtype in fp8_dtypes:
+                    converted_kwargs[key] = value.to(torch.bfloat16)
                 else:
                     converted_kwargs[key] = value
             
             args = tuple(converted_args)
             kwargs = converted_kwargs
-        else:
-            # For standard models: Conversion according to model dtype
-            if self.is_fp8_model:
-                # Convert FP8 → BFloat16 for calculations
-                converted_args = []
-                for arg in args:
-                    if isinstance(arg, torch.Tensor) and arg.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-                        converted_args.append(arg.to(torch.bfloat16))
-                    else:
-                        converted_args.append(arg)
-                
-                converted_kwargs = {}
-                for key, value in kwargs.items():
-                    if isinstance(value, torch.Tensor) and value.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-                        converted_kwargs[key] = value.to(torch.bfloat16)
-                    else:
-                        converted_kwargs[key] = value
-                
-                args = tuple(converted_args)
-                kwargs = converted_kwargs
-            elif self.is_fp16_model:
-                # Convert Float32 → FP16 for FP16 models
-                converted_args = []
-                for arg in args:
-                    if isinstance(arg, torch.Tensor) and arg.dtype == torch.float32:
-                        converted_args.append(arg.to(torch.float16))
-                    else:
-                        converted_args.append(arg)
-                
-                converted_kwargs = {}
-                for key, value in kwargs.items():
-                    if isinstance(value, torch.Tensor) and value.dtype == torch.float32:
-                        converted_kwargs[key] = value.to(torch.float16)
-                    else:
-                        converted_kwargs[key] = value
-                
-                args = tuple(converted_args)
-                kwargs = converted_kwargs
         
+        # Execute forward pass
         try:
             return self.dit_model(*args, **kwargs)
         except Exception as e:
-            print(f"❌ Error in forward pass: {e}")
-            print(f"   Model type: NaDiT 7B={is_nadit_7b}, NaDiT v2 3B={is_nadit_v2_3b}")
-            print(f"   Args dtypes: {[arg.dtype if isinstance(arg, torch.Tensor) else type(arg) for arg in args]}")
-            print(f"   Kwargs dtypes: {[(k, v.dtype if isinstance(v, torch.Tensor) else type(v)) for k, v in kwargs.items()]}")
+            print(f"❌ Forward pass error: {e}")
+            if self.is_fp8_model:
+                print(f"   FP8 model - converted FP8 tensors to BFloat16")
+            else:
+                print(f"   {self.model_dtype} model - no conversion applied")
             raise
     
     def __getattr__(self, name):
@@ -422,64 +321,3 @@ class FP8CompatibleDiT(torch.nn.Module):
                 setattr(self.dit_model, name, value)
             else:
                 super().__setattr__(name, value)
-
-
-def apply_fp8_compatibility_hooks(model: torch.nn.Module) -> List[Tuple[str, Any]]:
-    """
-    Hook system to intercept problematic FP8 modules
-    Alternative if the wrapper is not sufficient.
-    
-    Args:
-        model: Model to apply hooks to
-        
-    Returns:
-        List of (module_name, hook) tuples for cleanup
-    """
-    def create_fp8_safe_hook(original_dtype: torch.dtype):
-        def hook_fn(module, input, output):
-            # Convert FP8 output → BFloat16 if necessary for compatibility
-            if isinstance(output, torch.Tensor) and output.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-                # Temporarily keep in BFloat16 to avoid downstream errors
-                return output.to(torch.bfloat16)
-            elif isinstance(output, (tuple, list)):
-                # Handle multiple outputs
-                converted_output = []
-                for item in output:
-                    if isinstance(item, torch.Tensor) and item.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-                        converted_output.append(item.to(torch.bfloat16))
-                    else:
-                        converted_output.append(item)
-                return type(output)(converted_output)
-            return output
-        return hook_fn
-    
-    # Apply hooks to critical modules
-    problematic_modules = []
-    for name, module in model.named_modules():
-        # Identify RoPE and attention modules that cause FP8 problems
-        if any(keyword in name.lower() for keyword in ['rope', 'rotary', 'attention', 'mmattn']):
-            if hasattr(module, 'register_forward_hook'):
-                hook = module.register_forward_hook(create_fp8_safe_hook(torch.float8_e4m3fn))
-                problematic_modules.append((name, hook))
-    
-    print(f"🔧 Applied FP8 compatibility hooks to {len(problematic_modules)} modules")
-    return problematic_modules
-
-
-def remove_compatibility_hooks(hooks: List[Tuple[str, Any]]) -> None:
-    """
-    Remove previously applied compatibility hooks
-    
-    Args:
-        hooks: List of (module_name, hook) tuples from apply_fp8_compatibility_hooks
-    """
-    removed_count = 0
-    for name, hook in hooks:
-        try:
-            hook.remove()
-            removed_count += 1
-        except Exception as e:
-            print(f"⚠️ Failed to remove hook from {name}: {e}")
-    
-    print(f"🧹 Removed {removed_count}/{len(hooks)} compatibility hooks")
-

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -24,6 +24,7 @@ class FP8CompatibleDiT(torch.nn.Module):
         self.model_dtype = self._detect_model_dtype()
         self.is_fp8_model = self.model_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
         self.is_fp16_model = self.model_dtype == torch.float16
+        self._forward_count = 0
         
         # Only convert if not already done (e.g., when reusing cached weights)
         if not skip_conversion and self.is_fp8_model:
@@ -264,7 +265,8 @@ class FP8CompatibleDiT(torch.nn.Module):
             return module._original_forward(x, *args, **kwargs)
     
     def forward(self, *args, **kwargs):
-        """Forward pass with minimal dtype conversion overhead
+        """
+        Forward pass with minimal dtype conversion overhead
         
         Conversion strategy:
         - FP16 models: Keep everything in FP16 (no conversion needed)
@@ -272,15 +274,35 @@ class FP8CompatibleDiT(torch.nn.Module):
         - BFloat16 models: No conversion needed
         """
         
+        # Increment forward counter
+        self._forward_count += 1
+        
+        # === ADD BOUNDARY LOGGING ===
+        if self.is_fp8_model and hasattr(self, 'dit_model') and hasattr(self.dit_model, 'blocks'):
+            # Check if last block is FP16 (mixed precision)
+            try:
+                last_block = self.dit_model.blocks[-1]
+                last_block_dtype = next(last_block.parameters()).dtype
+                if last_block_dtype == torch.float16:
+                    # Log the boundary transition
+                    if self._forward_count % 100 == 0:  # Log every 100 forward passes
+                        print(f"[FP8CompatibleDiT] Mixed precision detected: FP8 model with FP16 last block")
+            except Exception as e:
+                # Silently handle if blocks structure is different
+                pass
+        
         # Only convert if we have an FP8 model for arithmetic operations 
         if self.is_fp8_model:
             fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
             
             # Convert args
             converted_args = []
-            for arg in args:
+            for i, arg in enumerate(args):
                 if isinstance(arg, torch.Tensor) and arg.dtype in fp8_dtypes:
                     converted_args.append(arg.to(torch.bfloat16))
+                    # === LOG CONVERSIONS ===
+                    if self._forward_count % 100 == 0:
+                        print(f"[FP8CompatibleDiT] Converting arg[{i}] from {arg.dtype} to bfloat16")
                 else:
                     converted_args.append(arg)
             
@@ -289,6 +311,8 @@ class FP8CompatibleDiT(torch.nn.Module):
             for key, value in kwargs.items():
                 if isinstance(value, torch.Tensor) and value.dtype in fp8_dtypes:
                     converted_kwargs[key] = value.to(torch.bfloat16)
+                    if self._forward_count % 100 == 0:
+                        print(f"[FP8CompatibleDiT] Converting kwarg[{key}] from {value.dtype} to bfloat16")
                 else:
                     converted_kwargs[key] = value
             

--- a/src/utils/downloads.py
+++ b/src/utils/downloads.py
@@ -1,73 +1,58 @@
 """
 Downloads utility module for SeedVR2
-Handles model and VAE downloads from HuggingFace Hub
-
-Extracted from: seedvr2.py (line 968-1015)
+Handles model and VAE downloads from HuggingFace repositories
 """
 
 import os
+import urllib.error
+from typing import Optional
 from torchvision.datasets.utils import download_url
-try:
-    import folder_paths
-    # Configuration des chemins
-    base_cache_dir = os.path.join(folder_paths.models_dir, "SEEDVR2")
 
-    # S'assurer que le dossier de cache existe
-    folder_paths.add_model_folder_path("seedvr2", os.path.join(folder_paths.models_dir, "SEEDVR2"))
-except:
-    base_cache_dir = "./seedvr2_models"
+from src.utils.model_registry import MODEL_REGISTRY, get_model_repo, DEFAULT_VAE
+from src.utils.constants import get_base_cache_dir
 
-def download_weight(model, model_dir=None):
+# HuggingFace URL template
+HUGGINGFACE_BASE_URL = "https://huggingface.co/{repo}/resolve/main/{filename}"
+
+def download_weight(model: str, model_dir: Optional[str] = None) -> None:
     """
-    Télécharge un modèle SeedVR2 et son VAE associé depuis HuggingFace Hub
+    Download a SeedVR2 model and its associated VAE from HuggingFace Hub
     
     Args:
-        model (str): Nom du fichier modèle à télécharger
-                    (ex: "seedvr2_ema_3b_fp16.safetensors")
-    
-    Gère automatiquement:
-    - Téléchargement du modèle principal
-    - Téléchargement du VAE avec fallbacks:
-      1. ema_vae_fp16.safetensors (priorité)
-      2. ema_vae_fp8_e4m3fn.safetensors (fallback)  
-      3. ema_vae.pth (legacy fallback)
+        model: Model filename to download
+        model_dir: Optional custom directory for models
     """
-    if model_dir is None:
-        model_path = os.path.join(base_cache_dir, model)
-        vae_fp16_path = os.path.join(base_cache_dir, "ema_vae_fp16.safetensors")
-        cache_dir = base_cache_dir
-    else:
-        model_path = os.path.join(model_dir, model)
-        vae_fp16_path = os.path.join(model_dir, "ema_vae_fp16.safetensors")
-        cache_dir = model_dir
-   
-    # Configuration HuggingFace
-    repo_id = "numz/SeedVR2_comfyUI"
-    base_url = f"https://huggingface.co/{repo_id}/resolve/main"
+    # Setup paths
+    cache_dir = model_dir or get_base_cache_dir()
+    model_path = os.path.join(cache_dir, model)
     
-    # 🚀 Téléchargement du modèle principal
+    # Download main model if not exists
     if not os.path.exists(model_path):
-        print(f"📥 Downloading model: {model}")
-        download_url(f"{base_url}/{model}", cache_dir, filename=model)
-        print(f"✅ Downloaded: {model}")
-    
-    # 🚀 Téléchargement du VAE avec stratégie de fallback
-    if not os.path.exists(vae_fp16_path):
-        print("📥 Downloading FP16 VAE SafeTensors...")
+        repo = get_model_repo(model)
+        url = HUGGINGFACE_BASE_URL.format(repo=repo, filename=model)
+        
+        print(f"📥 Downloading {model} from {repo}...")
         try:
-            download_url(f"{base_url}/ema_vae_fp16.safetensors", cache_dir, filename="ema_vae_fp16.safetensors")
-            print("✅ Downloaded: ema_vae_fp16.safetensors (FP16 SafeTensors)")
-        except Exception as e:
-            print(f"⚠️ FP16 SafeTensors VAE not available: {e}")
+            download_url(url, cache_dir, filename=model)
+            print(f"✅ Downloaded: {model}")
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            print(f"❌ Download failed: {e}")
+            print(f"📎 Please download manually from: https://huggingface.co/{repo}")
+            print(f"   and place it in: {cache_dir}")
+            return
     
-    return
-
-
-def get_base_cache_dir():
-    """
-    Retourne le répertoire de cache base pour les modèles SeedVR2
-    
-    Returns:
-        str: Chemin du répertoire de cache
-    """
-    return base_cache_dir
+    # Download VAE if model is in registry
+    if model in MODEL_REGISTRY:
+        vae_path = os.path.join(cache_dir, DEFAULT_VAE)
+        if not os.path.exists(vae_path):
+            vae_repo = get_model_repo(DEFAULT_VAE)
+            vae_url = HUGGINGFACE_BASE_URL.format(repo=vae_repo, filename=DEFAULT_VAE)
+            
+            print(f"📥 Downloading VAE: {DEFAULT_VAE}")
+            try:
+                download_url(vae_url, cache_dir, filename=DEFAULT_VAE)
+                print(f"✅ Downloaded: {DEFAULT_VAE}")
+            except (urllib.error.HTTPError, urllib.error.URLError) as e:
+                print(f"⚠️ VAE download failed: {e}")
+                print(f"📎 Please download VAE from: https://huggingface.co/{vae_repo}")
+                print(f"   and place it in: {cache_dir}")


### PR DESCRIPTION
This is a WIP PR - do not merge yet. Pushing it through for visibility.
- Keep FP8 model as FP8 for storage and BFloat16  for arithmetic operations (avoiding full bf16 conversion)
- Apply RoPE stability fix to prevent NaN propagation /  artifacts
- Centralize model registry and improve dynamic model discovery: allow sourcing models from multiple HF repos and user safetensors/gguf in their respective model directory
- Removed the 7B FP8 version from the default mode list (can still be added manually) and replaced with mixed precision fp8 to avoid artifacts

Will finish the GGUF integration based on @cmeka PR and do a few more testing before merging. Thanks