### PR TITLE
undefined 'devices' in SeedVR2 execute method +  batch merging terminology/log categories

### DIFF
--- a/src/interfaces/comfyui_node.py
+++ b/src/interfaces/comfyui_node.py
@@ -118,6 +118,7 @@ class SeedVR2:
             preserve_vram = False
             cache_model = False
             enable_debug = False
+            devices = get_device_list()
             device = devices[0]
         else:
             tiled_vae = extra_args["tiled_vae"]

--- a/src/interfaces/comfyui_node.py
+++ b/src/interfaces/comfyui_node.py
@@ -142,7 +142,7 @@ class SeedVR2:
         self.debug.log("\n─── Model Preparation ───", category="none")
         self.debug.start_timer("model_preparation")
         self.debug.log_memory_state("Execution start")
-        self.debug.log(f"Preparing model: {model}", category="general", force=True)
+        self.debug.log(f"Preparing model: {model}", category="model", force=True)
         
         # Check if download succeeded
         if not download_weight(model, debug=self.debug):


### PR DESCRIPTION
- **Fix** NameError: undefined 'devices' in SeedVR2 execute method
- **refactor**: clarify batch merging terminology and fix debug categories
1. Replace ambiguous 'block' terminology with 'batch merge' in generation.py to distinguish from BlockSwap transformer blocks
2. Use consistent 1-based indexing for batch numbers in merge operations
3. Improve merge operation messages for better user clarity
4. Fix debug log categories: batch merging -> 'video', model prep -> 'model'