### PR TITLE
Fix for the --prepend_frames logic

### DIFF
--- a/inference_cli.py
+++ b/inference_cli.py
@@ -130,8 +130,10 @@ def extract_frames_from_video(video_path, skip_first_frames=0, load_cap=None, pr
 
     # preprend frames if requested (reverse of the first few frames)
     if prepend_frames > 0:
-        prepend_frames = min(prepend_frames, len(frames))
-        frames = frames[-prepend_frames:] + frames
+        start_frames = []
+        if prepend_frames >= len(frames):  # repeat first (=last) frame
+            start_frames = [frames[-1]] * (prepend_frames - len(frames) + 1)
+        frames = start_frames + frames[prepend_frames:0:-1] + frames
 
     # Convert to tensor [T, H, W, C] and cast to Float16 for ComfyUI compatibility
     frames_tensor = torch.from_numpy(np.stack(frames)).to(torch.float16)


### PR DESCRIPTION
Fixed an issue with the --prepend_frames logic. Now it should behave as intended and also handle cases where the prepend_frames argument is larger than the number of frames (min clamp wouldn't work as then too many frames would be removed later)
> frames = [0,1,2,3,4,5,6] / prepend_frames = 3
> [3, 2, 1, 0, 1, 2, 3, 4, 5, 6]
> frames = [0,1,2,3,4,5,6] / prepend_frames = 8
> [6, 6, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6]