### PR TITLE
v2.5.5: Fix RAM leak for long videos via on-demand reconstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ We're actively working on improvements and new features. To stay informed:
 
 ## 🚀 Updates
 
+**2025.11.09 - Version 2.5.5**
+
+- 💾 **Memory: Fixed RAM leak for long videos** - On-demand reconstruction with lightweight batch indices instead of storing full transformed videos, fixed release_tensor_memory to handle CPU/CUDA/MPS consistently, and refactored batch processing helpers
+
 **2025.11.08 - Version 2.5.4**
 
 - 🎨 **Fix: AdaIN color correction** - Replace `.view()` with `.reshape()` to handle non-contiguous tensors after spatial padding, resolving "view size is not compatible with input tensor's size and stride" error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "seedvr2_videoupscaler"
 description = "SeedVR2 official ComfyUI integration: ByteDance-Seed's one-step diffusion-based video/image upscaling with memory-efficient inference"
-version = "2.5.4"
+version = "2.5.5"
 authors = [
     {name = "numz"},
     {name = "adrientoupet"}

--- a/src/core/generation_utils.py
+++ b/src/core/generation_utils.py
@@ -375,13 +375,11 @@ def setup_generation_context(
         'interrupt_fn': interrupt_fn,
         'video_transform': None,
         'text_embeds': None,
-        'all_transformed_videos': [],
         'all_latents': [],
         'all_upscaled_latents': [],
         'batch_samples': [],
         'final_video': None,
         'comfyui_available': comfyui_available,
-        'interrupt_fn': interrupt_fn,
     }
     
     if debug:

--- a/src/optimization/memory_manager.py
+++ b/src/optimization/memory_manager.py
@@ -423,12 +423,11 @@ def clear_rope_lru_caches(model: Optional[torch.nn.Module], debug: Optional['Deb
 
 
 def release_tensor_memory(tensor: Optional[torch.Tensor]) -> None:
-    """Release tensor memory properly without CPU allocation"""
+    """Release tensor memory from any device (CPU/CUDA/MPS)"""
     if tensor is not None and torch.is_tensor(tensor):
-        if tensor.is_cuda or tensor.is_mps:
-            # Release GPU memory directly without CPU transfer
-            if tensor.numel() > 0:
-                tensor.data.set_()
+        # Release storage for all devices (CPU, CUDA, MPS)
+        if tensor.numel() > 0:
+            tensor.data.set_()
         tensor.grad = None
 
 


### PR DESCRIPTION
- Replace all_transformed_videos storage with lightweight batch_metadata indices
- Reconstruct transformed videos on-demand in Phase 4 only when needed
- Add missing cleanup for input_images tensor in postprocess finally block
- Fix release_tensor_memory to handle CPU/CUDA/MPS consistently
- Extract helper functions for batch preparation and 4n+1 padding
- Remove duplicate interrupt_fn key from context initialization