### PR TITLE
Fix: Restore natural look for 7b model (v2.5.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ We're actively working on improvements and new features. To stay informed:
 
 ## 🚀 Updates
 
-**2025.11.09 - Version 2.5.5**
+**2025.11.09 - Version 2.5.6**
+
+- 🎨 **Fix: Restored natural look for 7b model** - Corrected torch.compile optimization that was causing overly plastic/ high-specular appearance in upscaled videos with 7b model.
 
 - 💾 **Memory: Fixed RAM leak for long videos** - On-demand reconstruction with lightweight batch indices instead of storing full transformed videos, fixed release_tensor_memory to handle CPU/CUDA/MPS consistently, and refactored batch processing helpers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "seedvr2_videoupscaler"
 description = "SeedVR2 official ComfyUI integration: ByteDance-Seed's one-step diffusion-based video/image upscaling with memory-efficient inference"
-version = "2.5.5"
+version = "2.5.6"
 authors = [
     {name = "numz"},
     {name = "adrientoupet"}


### PR DESCRIPTION
- Replace split-stack-mean with unflatten in unconcat_coalesce
- Corrects computation order to eliminate plastic/high-specular artifacts
- Maintains torch.compile compatibility (no .item() graph breaks)
- Applied to both dit_3b and dit_7b models