### PR TITLE
Allow cudnn attention

### DIFF
--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -532,11 +532,12 @@ class FP8CompatibleDiT(torch.nn.Module):
                 )
             else:
                 # Use optimized SDPA
-                with torch.backends.cuda.sdp_kernel(
-                    enable_flash=True,
-                    enable_math=True,
-                    enable_mem_efficient=True
-                ):
+                with torch.nn.attention.sdpa_kernel([
+                    torch.nn.attention.SDPBackend.MATH,
+                    torch.nn.attention.SDPBackend.FLASH_ATTENTION,
+                    torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+                    torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
+                ]):
                     attn_output = torch.nn.functional.scaled_dot_product_attention(
                         q, k, v,
                         dropout_p=0.0,


### PR DESCRIPTION
Basically like https://github.com/comfyanonymous/ComfyUI/commit/9df8792d4b894a8ea8034414ef63f70deee4b1af without any priority override.

Probably need some version gate depending on PyTorch version support

I patch it locally with only one backend

From Tridao's github benchmark it's better than FA2 / triton but worse than FA3 so might as well.

`TORCH_CUDNN_SDPA_PREFERRED=1` likely forces the selection for CUDNN - from a one shot test.