### PR TITLE
Refactor VAE upsamplers 

### DIFF
--- a/src/models/video_vae_v3/modules/video_vae.py
+++ b/src/models/video_vae_v3/modules/video_vae.py
@@ -352,18 +352,15 @@ class DownEncoderBlock3D(nn.Module):
 
         self.resnets = nn.ModuleList(resnets)
 
-        self.downsamplers = None
+        self.downsamplers = nn.ModuleList()
         if add_downsample:
-            # Todo: Refactor this line before V5 Image VAE Training.
-            self.downsamplers = nn.ModuleList(
-                [
-                    Downsample3D(
-                        channels=out_channels,
-                        inflation_mode=inflation_mode,
-                        temporal_down=temporal_down,
-                        spatial_down=spatial_down,
-                    )
-                ]
+            self.downsamplers.append(
+                Downsample3D(
+                    channels=out_channels,
+                    inflation_mode=inflation_mode,
+                    temporal_down=temporal_down,
+                    spatial_down=spatial_down,
+                )
             )
 
     def forward(
@@ -372,9 +369,8 @@ class DownEncoderBlock3D(nn.Module):
         for resnet in self.resnets:
             hidden_states = resnet(hidden_states, memory_state=memory_state)
 
-        if self.downsamplers is not None:
-            for downsampler in self.downsamplers:
-                hidden_states = downsampler(hidden_states, memory_state=memory_state)
+        for downsampler in self.downsamplers:
+            hidden_states = downsampler(hidden_states, memory_state=memory_state)
 
         return hidden_states
 
@@ -411,19 +407,16 @@ class UpDecoderBlock3D(nn.Module):
 
         self.resnets = nn.ModuleList(resnets)
 
-        self.upsamplers = None
-        # Todo: Refactor this line before V5 Image VAE Training.
+        self.upsamplers = nn.ModuleList()
         if add_upsample:
-            self.upsamplers = nn.ModuleList(
-                [
-                    Upsample3D(
-                        channels=out_channels,
-                        inflation_mode=inflation_mode,
-                        temporal_up=temporal_up,
-                        spatial_up=spatial_up,
-                        slicing=slicing,
-                    )
-                ]
+            self.upsamplers.append(
+                Upsample3D(
+                    channels=out_channels,
+                    inflation_mode=inflation_mode,
+                    temporal_up=temporal_up,
+                    spatial_up=spatial_up,
+                    slicing=slicing,
+                )
             )
 
     def forward(
@@ -432,9 +425,8 @@ class UpDecoderBlock3D(nn.Module):
         for resnet in self.resnets:
             hidden_states = resnet(hidden_states, memory_state=memory_state)
 
-        if self.upsamplers is not None:
-            for upsampler in self.upsamplers:
-                hidden_states = upsampler(hidden_states, memory_state=memory_state)
+        for upsampler in self.upsamplers:
+            hidden_states = upsampler(hidden_states, memory_state=memory_state)
 
         return hidden_states
 


### PR DESCRIPTION
Refactored the initialization of `upsamplers` and `downsamplers` in `src/models/video_vae_v3/modules/video_vae.py`. Instead of initializing to `None` and conditionally creating a `ModuleList`, the code now initializes an empty `ModuleList` and appends the module if required. This simplifies the `forward` pass by removing null checks and prepares the structure for potential future extensions (V5). Verified that state dict keys for existing configurations remain compatible.