### PR TITLE
Reduce memory usage on MPS by clearing cache after each `encode` & `decode` operation

### DIFF
--- a/src/models/video_vae_v3/modules/attn_video_vae.py
+++ b/src/models/video_vae_v3/modules/attn_video_vae.py
@@ -51,7 +51,7 @@ from .types import (
     _memory_device_t,
     _receptive_field_t,
 )
-from ....optimization.memory_manager import retry_on_oom
+from ....optimization.memory_manager import is_mps_available, retry_on_oom
 
 logger = get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -1224,6 +1224,9 @@ class VideoAutoencoderKL(diffusers.AutoencoderKL):
         
         output = causal_conv_gather_outputs(output)
         
+        if is_mps_available():
+            torch.mps.empty_cache()
+
         # Only transfer back if needed
         return output if output.device == x.device else output.to(x.device)
 
@@ -1240,6 +1243,9 @@ class VideoAutoencoderKL(diffusers.AutoencoderKL):
         output = self.decoder(_z, memory_state=memory_state)
         output = causal_conv_gather_outputs(output)
         
+        if is_mps_available():
+            torch.mps.empty_cache()
+
         # Only transfer back if needed
         return output if output.device == z.device else output.to(z.device)
 


### PR DESCRIPTION
This PR reduces the amount of memory leaked on my machine with **tiled** VAE encoding and decoding (tile_size = 1024), by using the workaround shown in https://github.com/pytorch/pytorch/issues/155060.

Adding `gc.collect()` lines to the same places can further reduce memory usage in VAE steps to constant ~10GB with tiling size of 1024, but it comes with minutes of performance penalty so I didn't include that. Now it uses up ~30GB for me without speed compromise, which is personally acceptable, and I think the overall usage is adjustable with `PYTORCH_MPS_LOW_WATERMARK_RATIO`.

May fix #415, #363, #410.

Would you like to try this PR out and see if it solves the problem for you and if there's any performance impact? @jackdaw-vfx @atruongn @saik0s