### PR TITLE
v2.5.24: Restores the MPS memory leak workaround that was accidentally removed during code cleanup in v2.5.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ We're actively working on improvements and new features. To stay informed:
 
 ## 🚀 Release Notes
 
+**2025.12.24 - Version 2.5.24**
+
+- **🍎 Fix: MPS memory leak regression** - Restored MPS cache clearing after VAE encode/decode operations that was accidentally removed during code cleanup in v2.5.23
+
 **2025.12.24 - Version 2.5.23**
 
 - **🔒 Security: Prevent code execution in model loading** - Added protection against malicious .pth files by restricting deserialization to tensors only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "seedvr2_videoupscaler"
 description = "SeedVR2 official ComfyUI integration: ByteDance-Seed's one-step diffusion-based video/image upscaling with memory-efficient inference"
-version = "2.5.23"
+version = "2.5.24"
 authors = [
     {name = "numz"},
     {name = "adrientoupet"}

--- a/src/models/video_vae_v3/modules/attn_video_vae.py
+++ b/src/models/video_vae_v3/modules/attn_video_vae.py
@@ -1224,6 +1224,10 @@ class VideoAutoencoderKL(diffusers.AutoencoderKL):
         
         output = causal_conv_gather_outputs(output)
         
+        # MPS memory leak workaround (pytorch/pytorch#155060)
+        if self.device.type == 'mps':
+            torch.mps.empty_cache()
+        
         # Only transfer back if needed
         return output if output.device == x.device else output.to(x.device)
 
@@ -1239,6 +1243,10 @@ class VideoAutoencoderKL(diffusers.AutoencoderKL):
         
         output = self.decoder(_z, memory_state=memory_state)
         output = causal_conv_gather_outputs(output)
+        
+        # MPS memory leak workaround (pytorch/pytorch#155060)
+        if self.device.type == 'mps':
+            torch.mps.empty_cache()
         
         # Only transfer back if needed
         return output if output.device == z.device else output.to(z.device)

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -4,7 +4,7 @@ Only includes constants actually used in the codebase
 """
 
 # Version information
-__version__ = "2.5.23"
+__version__ = "2.5.24"
 
 import os
 import warnings


### PR DESCRIPTION
## Changes
- **Fix: MPS memory leak regression** - Re-added `torch.mps.empty_cache()` calls after VAE encode/decode operations in `attn_video_vae.py`
- Addresses PyTorch MPS memory leak (pytorch/pytorch#155060) where padding operations accumulate memory
- Only triggers cache clear when VAE device is actually MPS

## Files Changed
- `src/models/video_vae_v3/modules/attn_video_vae.py` - Restored MPS workaround in `_encode()` and `_decode()` methods

## Regression Details
The MPS memory optimization was correctly added in v2.5.23 but was inadvertently removed during final cleanup. This restores the original intended functionality for Apple Silicon users.