### PR TITLE
ROCm repeat interleave HIP error

### DIFF
--- a/src/models/dit_3b/modulation.py
+++ b/src/models/dit_3b/modulation.py
@@ -19,6 +19,7 @@ from torch import nn
 
 from ...common.cache import Cache
 from ...common.distributed.ops import slice_inputs
+from ...optimization.compatibility import portable_repeat_interleave
 
 # (dim: int, emb_dim: int)
 ada_layer_type = Callable[[int, int], nn.Module]
@@ -80,7 +81,7 @@ class AdaSingle(nn.Module):
             emb = cache(
                 f"emb_repeat_{idx}_{branch_tag}",
                 lambda: slice_inputs(
-                    torch.repeat_interleave(emb, hid_len, dim=0),
+                    portable_repeat_interleave(emb, hid_len, dim=0),
                     dim=0,
                 ),
             )

--- a/src/models/dit_3b/nablocks/attention/mmattn.py
+++ b/src/models/dit_3b/nablocks/attention/mmattn.py
@@ -22,6 +22,7 @@ from torch.nn.modules.utils import _triple
 from .....common.cache import Cache
 from .....common.distributed.ops import gather_heads_scatter_seq, gather_seq_scatter_heads_qkv
 from .....common.half_precision_fixes import safe_pad_operation
+from .....optimization.compatibility import portable_repeat_interleave
 
 from ... import na
 from ...attention import FlashAttentionVarlen
@@ -210,7 +211,7 @@ class NaSwinAttention(NaMMAttention):
         txt_len = cache("txt_len", lambda: txt_shape.prod(-1))
 
         vid_len_win = cache_win("vid_len", lambda: window_shape.prod(-1))
-        txt_len_win = cache_win("txt_len", lambda: txt_len.repeat_interleave(window_count))
+        txt_len_win = cache_win("txt_len", lambda: portable_repeat_interleave(txt_len, window_count, dim=0))
         all_len_win = cache_win("all_len", lambda: vid_len_win + txt_len_win)
         concat_win, unconcat_win = cache_win(
             "mm_pnp", lambda: na.repeat_concat_idx(vid_len_win, txt_len, window_count)

--- a/src/models/dit_7b/modulation.py
+++ b/src/models/dit_7b/modulation.py
@@ -19,6 +19,7 @@ from torch import nn
 
 from ...common.cache import Cache
 from ...common.distributed.ops import slice_inputs
+from ...optimization.compatibility import portable_repeat_interleave
 
 # (dim: int, emb_dim: int)
 ada_layer_type = Callable[[int, int], nn.Module]
@@ -75,7 +76,7 @@ class AdaSingle(nn.Module):
             emb = cache(
                 f"emb_repeat_{idx}_{branch_tag}",
                 lambda: slice_inputs(
-                    torch.repeat_interleave(emb, hid_len, dim=0),
+                    portable_repeat_interleave(emb, hid_len, dim=0),
                     dim=0,
                 ),
             )

--- a/src/models/dit_7b/nablocks/mmsr_block.py
+++ b/src/models/dit_7b/nablocks/mmsr_block.py
@@ -20,6 +20,7 @@ from torch.nn import functional as F
 # from ..cache import Cache
 from ....common.cache import Cache
 from ....common.distributed.ops import gather_heads_scatter_seq, gather_seq_scatter_heads_qkv
+from ....optimization.compatibility import portable_repeat_interleave
 
 from .. import na
 from ..attention import FlashAttentionVarlen
@@ -117,7 +118,7 @@ class NaSwinAttention(MMWindowAttention):
         txt_len = cache("txt_len", lambda: txt_shape.prod(-1))
 
         vid_len_win = cache_win("vid_len", lambda: window_shape.prod(-1))
-        txt_len_win = cache_win("txt_len", lambda: txt_len.repeat_interleave(window_count))
+        txt_len_win = cache_win("txt_len", lambda: portable_repeat_interleave(txt_len, window_count, dim=0))
         all_len_win = cache_win("all_len", lambda: vid_len_win + txt_len_win)
         concat_win, unconcat_win = cache_win(
             "mm_pnp", lambda: na.repeat_concat_idx(vid_len_win, txt_len, window_count)

--- a/src/optimization/__init__.py
+++ b/src/optimization/__init__.py
@@ -1,18 +1,3 @@
-# // Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
-# // Modifications Copyright (c) 2025-2026 SeedVR2 Contributors
-# //
-# // Licensed under the Apache License, Version 2.0 (the "License");
-# // you may not use this file except in compliance with the License.
-# // You may obtain a copy of the License at
-# //
-# //     http://www.apache.org/licenses/LICENSE-2.0
-# //
-# // Unless required by applicable law or agreed to in writing, software
-# // distributed under the License is distributed on an "AS IS" BASIS,
-# // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# // See the License for the specific language governing permissions and
-# // limitations under the License.
-
 """
 Optimization utilities for SeedVR2 Video Upscaler.
 

--- a/src/optimization/__init__.py
+++ b/src/optimization/__init__.py
@@ -1,0 +1,29 @@
+# // Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+# // Modifications Copyright (c) 2025-2026 SeedVR2 Contributors
+# //
+# // Licensed under the Apache License, Version 2.0 (the "License");
+# // you may not use this file except in compliance with the License.
+# // You may obtain a copy of the License at
+# //
+# //     http://www.apache.org/licenses/LICENSE-2.0
+# //
+# // Unless required by applicable law or agreed to in writing, software
+# // distributed under the License is distributed on an "AS IS" BASIS,
+# // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# // See the License for the specific language governing permissions and
+# // limitations under the License.
+
+"""
+Optimization utilities for SeedVR2 Video Upscaler.
+
+Exports:
+    IS_ROCM: Boolean indicating if running on AMD ROCm/HIP backend
+    portable_repeat_interleave: Cross-platform repeat_interleave that works on ROCm
+"""
+
+from .compatibility import IS_ROCM, portable_repeat_interleave
+
+__all__ = [
+    "IS_ROCM",
+    "portable_repeat_interleave",
+]


### PR DESCRIPTION
fix: replace repeat_interleave with portable impl for ROCm compatibility (#479)

torch.repeat_interleave triggers hipErrorIllegalState on AMD ROCm 6.4
when using tensor indices. This adds portable_repeat_interleave() that
uses index_select on ROCm while keeping native behavior on CUDA/CPU.

Fixes:
- src/models/dit_7b/modulation.py
- src/models/dit_3b/modulation.py
- src/models/dit_7b/nablocks/mmsr_block.py
- src/models/dit_3b/nablocks/attention/mmattn.py

The portable implementation handles both scalar and tensor repeats,
with debug logging support for tensor state diagnostics.