### PR TITLE
Small fix in inference cli: Do final multiplication in Pytorch instead

### DIFF
--- a/inference_cli.py
+++ b/inference_cli.py
@@ -587,7 +587,7 @@ def process_single_file(input_path: str, args: argparse.Namespace, device_list: 
     
     # Save single image
     os.makedirs(Path(output_path).parent, exist_ok=True)
-    frame_np = (result[0].cpu().numpy() * 255.0).astype(np.uint8)
+    frame_np = result[0].cpu().mul(255.0).clamp_(0, 255).to(torch.uint8).numpy()
     _save_image_bgr(frame_np, output_path)
     
     debug.log(f"Output saved to: {output_path}", category="file", force=True)
@@ -760,7 +760,7 @@ def save_frames_to_video(
     Raises:
         ValueError: If video writer cannot be initialized
     """
-    frames_np = (frames_tensor.cpu().numpy() * 255.0).astype(np.uint8)
+    frames_np = frames_tensor.cpu().mul(255.0).clamp_(0, 255).to(torch.uint8).numpy()
     T, H, W, C = frames_np.shape
     
     if writer is None:
@@ -806,7 +806,7 @@ def save_frames_to_image(
     """
     os.makedirs(output_dir, exist_ok=True)
     
-    frames_np = (frames_tensor.cpu().numpy() * 255.0).astype(np.uint8)
+    frames_np = frames_tensor.cpu().mul(255.0).clamp_(0, 255).to(torch.uint8).numpy()
     total = frames_np.shape[0]
     
     if start_index == 0:


### PR DESCRIPTION
Hi, first of all: Thanks for the nice software and especially the great docs, running the model is really a breeze with this tooling.

I've run this in standalone mode on a RTX 5090 server node to process a >1h video files  in ~10 minute chunks and noticed noticeable slowdown (more than 10 minutes) after each chunk, with only a single core out of 192 actually doing anything. I think the culprit is doing this final transformation in numpy instead of e.g. pytorch, multiplying first in pytorch and then casting to numpy removed the bottleneck. The `clamp` is just to make the transformation a bit more obvious wrt. value range. 
I've only tested this with a video file in a single-GPU setup on that specific machine and there might be ways to do this better (e.g. multiplying entirely on the GPU) but I think this already solves the issue sufficiently.
Let me know what you think and thanks again for the great project!