### PR TITLE
Add experimental Intel XPU backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,79 @@
 # ComfyUI SeedVR2 Intel XPU Fork
 
-This fork tracks `numz/ComfyUI-SeedVR2_VideoUpscaler` and adds experimental Intel XPU / PyTorch XPU support for ComfyUI users running on Intel Arc and Core Ultra integrated GPUs.
+This fork tracks `numz/ComfyUI-SeedVR2_VideoUpscaler` and adds experimental Intel XPU / PyTorch XPU support for ComfyUI users running on Intel Arc and Core Ultra GPUs.
 
-The goal is to make SeedVR2 discoverable and usable on systems where `torch.xpu.is_available()` is true, without requiring CUDA. It exposes Intel devices such as `xpu:0` in the DiT and VAE loader nodes, adds conservative shared-memory reporting for Intel iGPU/XPU systems, and keeps the default attention path on PyTorch SDPA rather than CUDA-only Flash/Sage Attention.
+The goal is to make SeedVR2 discoverable and usable on systems where `torch.xpu.is_available()` is true, without requiring CUDA. It exposes Intel devices such as `xpu:0` in the DiT and VAE loader nodes, adds conservative shared-memory reporting for Intel iGPU/XPU systems, keeps PyTorch SDPA as the safe default attention path, and optionally enables Intel Omni XPU SDP attention through `attention_mode=omni_xpu`.
 
-This Intel XPU support code was generated with Codex and is based on local testing plus implementation ideas from Intel's `llm-scaler` Omni patch set:
+This Intel XPU support code was generated with Codex and is based on local testing plus implementation ideas from Intel's `llm-scaler` Omni patch set and ComfyUI optimization node:
 
-https://github.com/intel/llm-scaler/tree/main/omni/patches
+- https://github.com/intel/llm-scaler/tree/main/omni/patches
+- https://github.com/intel/llm-scaler/tree/main/omni/ComfyUI-OmniXPU
+
+## Intel XPU Omni Attention
+
+`attention_mode=omni_xpu` uses `omni_xpu_kernel.sdp` as a FlashAttention-style SDP path for supported Intel XPU tensors. It is optional: if the kernel is missing or a shape is unsupported, this fork falls back to PyTorch SDPA and logs the reason.
+
+Supported fast-path cases are intentionally conservative:
+
+- Intel XPU tensor on `xpu:0`
+- `torch.float16` or `torch.bfloat16`
+- head dimension 64 or 128
+- no dropout, no causal mask, no custom softmax scale
+- self-attention packed sequences where q/k/v lengths match
+
+Unsupported cases fall back to SDPA. SeedVR2 7B also contains internal window/masked attention paths that can still use PyTorch SDPA; this is expected.
+
+### Install with Intel ComfyUI-OmniXPU
+
+This fork only adds the SeedVR2-side `omni_xpu` attention option. For the actual Intel SDP kernel and ComfyUI monkey patches, install Intel's ComfyUI-OmniXPU node:
+
+```bat
+cd /d D:\ComfyUI_windows_portable\ComfyUI\custom_nodes
+git clone https://github.com/intel/llm-scaler.git llm-scaler
+xcopy llm-scaler\omni\ComfyUI-OmniXPU ComfyUI-OmniXPU /E /I /Y
+```
+
+Then install a matching `omni_xpu_kernel` wheel into ComfyUI portable Python:
+
+```bat
+D:\ComfyUI_windows_portable\python_embeded\python.exe -m pip install --force-reinstall --no-deps path\to\omni_xpu_kernel-0.1.0-cp313-cp313-win_amd64.whl
+```
+
+This fork's `wheels/` directory may contain locally built Windows CPython 3.13 wheels for common Intel XPU targets. These wheels are community builds for ComfyUI portable Python 3.13 and are not official Intel releases.
+
+| Wheel folder | Intended devices | Build target |
+| --- | --- | --- |
+| `wheels/ptl_h` | Core Ultra Series 3 / Panther Lake, Arc B390/B370 style integrated graphics | `ptl-h` |
+| `wheels/xe3_lpg` | Generic Xe3-LPG fallback | `xe3-lpg` |
+| `wheels/xe2_lpg` | Core Ultra Series 2 / Lunar Lake and Arrow Lake-H integrated Arc 140V/140T style graphics | `xe2-lpg` |
+| `wheels/lnl_m` | Lunar Lake narrow target, use only if the generic Xe2 wheel is not suitable | `lnl-m` |
+| `wheels/bmg` | Discrete Arc B-series / Battlemage | `bmg` |
+
+Notes:
+
+- Panther Lake / Arc B390/B370 style integrated GPUs should use `ptl_h`, not `bmg`.
+- Arrow Lake-H / Arc 140T should use the generic `xe2_lpg` wheel. The experimental `arl-h` AOT target failed to build in local testing, so it is not distributed here.
+- Meteor Lake / Core Ultra Series 1 wheels are not included in this fork release because the local `mtl-h` build did not complete successfully.
+- Users do not need the full Intel oneAPI compiler runtime to run these wheels, but the required runtime DLLs must be available in the ComfyUI portable Python environment.
+
+### Known Intel XPU Notes
+
+- Keep `OMNIXPU_NORM=0` unless you are specifically testing Intel norm kernels. In local Z-Image testing, OmniXPU's RMSNorm path could crash inside the native SYCL/C++ kernel. SeedVR2 `omni_xpu` attention does not require the norm patch.
+- Avoid rebinding `transformers` lazy modules with `getattr(mod, name, None)` when monkey-patching `sys.modules`; it can trigger noisy lazy imports. Check `mod.__dict__` instead.
+- Be careful with `comfy.rmsnorm.rms_norm`: it is a functional RMSNorm path used by several ComfyUI models. Patching it globally can affect models outside SeedVR2.
+- CacheDiT is not recommended for low-step Z-Image-Turbo workflows. Aggressive settings can degrade image quality; conservative defaults can produce 0 cache hits and no speedup. It is unrelated to SeedVR2 `omni_xpu` attention.
+- `torch.compile` may recompile frequently on interactive prompt/shape changes and can be slower than eager mode for this workflow.
 
 Validated locally on Windows portable ComfyUI with PyTorch `2.12.0+xpu` and Intel Core Ultra x7 358H:
 
-- DiT: `seedvr2_ema_7b-Q8_0.gguf`
+- DiT: `seedvr2_ema_3b-Q8_0.gguf` and `seedvr2_ema_7b-Q8_0.gguf`
 - VAE: `ema_vae_fp16.safetensors`
 - Device: `xpu:0`
-- Attention: `sdpa`
+- Attention: `sdpa` and `omni_xpu`
 - 768x768 image to 1080x1080
 - 1280x720 image to 3640x2048 with tiled VAE encode/decode
 - 1280x720 RGBA image to 3640x2048 using 7B Q8 GGUF completed successfully in 110.58 seconds on the tested Intel XPU setup
+- Z-Image-Turbo Q8 + SeedVR2 3B Q8 workflow completed successfully with `attention_mode=omni_xpu`; local first-run timing improved from about 166 seconds with SDPA to about 150 seconds with Omni XPU attention on the tested setup
 
 Additional XPU compatibility improvements adapted from the Intel Omni patch approach include XPU-aware tensor offload checks, torchvision resize fallback settings, XPU output tensor handling, safetensors CPU-intermediate fallback for XPU allocation errors, and more complete XPU memory cleanup paths.
 
@@ -24,7 +81,7 @@ Suggested Intel XPU starting settings:
 
 - DiT device: `xpu:0`
 - VAE device: `xpu:0`
-- Attention mode: `sdpa`
+- Attention mode: `omni_xpu` if `omni_xpu_kernel` is installed, otherwise `sdpa`
 - Batch size: `1` for single images
 - Offload device: `cpu`
 - Torch compile: leave disconnected for interactive image upscaling
@@ -500,6 +557,7 @@ Configure the DiT (Diffusion Transformer) model for video upscaling.
 
 - **attention_mode**: Attention computation backend
   - `sdpa`: PyTorch scaled_dot_product_attention (default, always available)
+  - `omni_xpu`: Intel Omni XPU SDP (Intel GPU, requires omni_xpu_kernel)
   - `flash_attn_2`: Flash Attention 2 (Ampere+, requires flash-attn package)
   - `flash_attn_3`: Flash Attention 3 (Hopper+, requires flash-attn with FA3 support)
   - `sageattn_2`: SageAttention 2 (requires sageattention package)
@@ -967,7 +1025,7 @@ python inference_cli.py media_folder/ \
 
 **Performance Optimization:**
 - `--allow_vram_overflow`: Allow VRAM overflow to system RAM. Prevents OOM but may cause severe slowdown
-- `--attention_mode`: Attention backend: 'sdpa' (default), 'flash_attn_2' (Ampere+), 'flash_attn_3' (Hopper+), 'sageattn_2', or 'sageattn_3' (Blackwell)
+- `--attention_mode`: Attention backend: 'sdpa' (default), 'omni_xpu' (Intel XPU), 'flash_attn_2' (Ampere+), 'flash_attn_3' (Hopper+), 'sageattn_2', or 'sageattn_3' (Blackwell)
 - `--compile_dit`: Enable torch.compile for DiT model (20-40% speedup, requires PyTorch 2.0+ and Triton)
 - `--compile_vae`: Enable torch.compile for VAE model (15-25% speedup, requires PyTorch 2.0+ and Triton)
 - `--compile_backend`: Compilation backend: 'inductor' (full optimization) or 'cudagraphs' (lightweight) (default: inductor)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+# ComfyUI SeedVR2 Intel XPU Fork
+
+This fork tracks `numz/ComfyUI-SeedVR2_VideoUpscaler` and adds experimental Intel XPU / PyTorch XPU support for ComfyUI users running on Intel Arc and Core Ultra integrated GPUs.
+
+The goal is to make SeedVR2 discoverable and usable on systems where `torch.xpu.is_available()` is true, without requiring CUDA. It exposes Intel devices such as `xpu:0` in the DiT and VAE loader nodes, adds conservative shared-memory reporting for Intel iGPU/XPU systems, and keeps the default attention path on PyTorch SDPA rather than CUDA-only Flash/Sage Attention.
+
+Validated locally on Windows portable ComfyUI with PyTorch `2.12.0+xpu` and Intel Core Ultra x7 358H:
+
+- DiT: `seedvr2_ema_7b-Q8_0.gguf`
+- VAE: `ema_vae_fp16.safetensors`
+- Device: `xpu:0`
+- Attention: `sdpa`
+- 768x768 image to 1080x1080
+- 1280x720 image to 3640x2048 with tiled VAE encode/decode
+
+Suggested Intel XPU starting settings:
+
+- DiT device: `xpu:0`
+- VAE device: `xpu:0`
+- Attention mode: `sdpa`
+- Batch size: `1` for single images
+- Offload device: `cpu`
+- Torch compile: leave disconnected for interactive image upscaling
+
+This is experimental community work, not official Intel or upstream SeedVR2 support. CUDA-only acceleration backends such as Flash Attention and SageAttention are not enabled for XPU by this fork.
+
+Upstream PR: https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler/pull/590
+
+---
 # ComfyUI-SeedVR2_VideoUpscaler
 
 [![View Code](https://img.shields.io/badge/📂_View_Code-GitHub-181717?style=for-the-badge&logo=github)](https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This fork tracks `numz/ComfyUI-SeedVR2_VideoUpscaler` and adds experimental Inte
 
 The goal is to make SeedVR2 discoverable and usable on systems where `torch.xpu.is_available()` is true, without requiring CUDA. It exposes Intel devices such as `xpu:0` in the DiT and VAE loader nodes, adds conservative shared-memory reporting for Intel iGPU/XPU systems, and keeps the default attention path on PyTorch SDPA rather than CUDA-only Flash/Sage Attention.
 
+This Intel XPU support code was generated with Codex and is based on local testing plus implementation ideas from Intel's `llm-scaler` Omni patch set:
+
+https://github.com/intel/llm-scaler/tree/main/omni/patches
+
 Validated locally on Windows portable ComfyUI with PyTorch `2.12.0+xpu` and Intel Core Ultra x7 358H:
 
 - DiT: `seedvr2_ema_7b-Q8_0.gguf`
@@ -12,6 +16,9 @@ Validated locally on Windows portable ComfyUI with PyTorch `2.12.0+xpu` and Inte
 - Attention: `sdpa`
 - 768x768 image to 1080x1080
 - 1280x720 image to 3640x2048 with tiled VAE encode/decode
+- 1280x720 RGBA image to 3640x2048 using 7B Q8 GGUF completed successfully in 110.58 seconds on the tested Intel XPU setup
+
+Additional XPU compatibility improvements adapted from the Intel Omni patch approach include XPU-aware tensor offload checks, torchvision resize fallback settings, XPU output tensor handling, safetensors CPU-intermediate fallback for XPU allocation errors, and more complete XPU memory cleanup paths.
 
 Suggested Intel XPU starting settings:
 

--- a/inference_cli.py
+++ b/inference_cli.py
@@ -1446,8 +1446,8 @@ Examples:
     # Performance
     perf_group = parser.add_argument_group('Performance optimization')
     perf_group.add_argument("--attention_mode", type=str, default="sdpa",
-                        choices=["sdpa", "flash_attn_2", "flash_attn_3", "sageattn_2", "sageattn_3"],
-                        help="Attention backend: 'sdpa' (default), 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3' (Blackwell GPUs)")
+                        choices=["sdpa", "omni_xpu", "flash_attn_2", "flash_attn_3", "sageattn_2", "sageattn_3"],
+                        help="Attention backend: 'sdpa' (default), 'omni_xpu' (Intel XPU), 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3' (Blackwell GPUs)")
     perf_group.add_argument("--compile_dit", action="store_true", 
                         help="Enable torch.compile for DiT model (20-40%% speedup, requires PyTorch 2.0+ and Triton)")
     perf_group.add_argument("--compile_vae", action="store_true",

--- a/src/common/distributed/basic.py
+++ b/src/common/distributed/basic.py
@@ -21,7 +21,7 @@ from datetime import timedelta
 import torch
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel
-from ...optimization.memory_manager import is_mps_available
+from ...optimization.memory_manager import is_mps_available, is_xpu_available
 
 def get_global_rank() -> int:
     """
@@ -48,6 +48,8 @@ def get_device() -> torch.device:
     """
     Get current rank device.
     """
+    if is_xpu_available():
+        return torch.device("xpu", get_local_rank())
     if is_mps_available():
         return torch.device("mps")
     return torch.device("cuda", get_local_rank())
@@ -76,7 +78,6 @@ def init_torch(cudnn_benchmark=True, timeout=timedelta(seconds=600)):
         timeout=timeout,
     )
 
-
 def convert_to_ddp(module: torch.nn.Module, **kwargs) -> DistributedDataParallel:
     return DistributedDataParallel(
         module=module,
@@ -84,4 +85,3 @@ def convert_to_ddp(module: torch.nn.Module, **kwargs) -> DistributedDataParallel
         output_device=get_local_rank(),
         **kwargs,
     )
-    

--- a/src/core/generation_phases.py
+++ b/src/core/generation_phases.py
@@ -492,7 +492,7 @@ def encode_all_batches(
             del transformed_video, rgb_video
             
             # Convert from VAE dtype to compute dtype and offload to avoid VRAM accumulation
-            if ctx['tensor_offload_device'] is not None and (cond_latents[0].is_cuda or cond_latents[0].is_mps):
+            if ctx['tensor_offload_device'] is not None and (cond_latents[0].is_cuda or cond_latents[0].is_mps or cond_latents[0].is_xpu):
                 ctx['all_latents'][encode_idx] = manage_tensor(
                     tensor=cond_latents[0],
                     target_device=ctx['tensor_offload_device'],
@@ -731,7 +731,7 @@ def upscale_all_batches(
             debug.end_timer(f"dit_inference_{upscale_idx+1}", f"DiT inference {upscale_idx+1}")
             
             # Offload upscaled latents to avoid VRAM accumulation
-            if ctx['tensor_offload_device'] is not None and (upscaled_latents[0].is_cuda or upscaled_latents[0].is_mps):
+            if ctx['tensor_offload_device'] is not None and (upscaled_latents[0].is_cuda or upscaled_latents[0].is_mps or upscaled_latents[0].is_xpu):
                 ctx['all_upscaled_latents'][upscale_idx] = manage_tensor(
                     tensor=upscaled_latents[0],
                     target_device=ctx['tensor_offload_device'],

--- a/src/core/generation_utils.py
+++ b/src/core/generation_utils.py
@@ -462,7 +462,7 @@ def prepare_runner(
         decode_tile_size: Tile size for decoding (height, width)
         decode_tile_overlap: Tile overlap for decoding (height, width)
         tile_debug: Tile visualization mode (false/encode/decode)
-        attention_mode: Attention computation backend ('sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
+        attention_mode: Attention computation backend ('sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
         torch_compile_args_dit: Optional torch.compile configuration for DiT model
         torch_compile_args_vae: Optional torch.compile configuration for VAE model
         

--- a/src/core/model_configuration.py
+++ b/src/core/model_configuration.py
@@ -171,7 +171,7 @@ def _describe_attention_mode(attention_mode: Optional[str]) -> str:
     Generate human-readable description of attention mode configuration.
     
     Args:
-        attention_mode: Attention mode string ('sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
+        attention_mode: Attention mode string ('sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
         
     Returns:
         Human-readable description string
@@ -181,6 +181,7 @@ def _describe_attention_mode(attention_mode: Optional[str]) -> str:
     
     mode_descriptions = {
         'sdpa': 'PyTorch SDPA',
+        'omni_xpu': 'Intel Omni XPU SDP',
         'flash_attn_2': 'Flash Attention 2',
         'flash_attn_3': 'Flash Attention 3',
         'sageattn_2': 'SageAttention 2',
@@ -439,7 +440,7 @@ def _update_dit_config(
             - dynamic: bool - Enable dynamic shapes
             - dynamo_cache_size_limit: int - Cache size limit
             - dynamo_recompile_limit: int - Recompilation limit
-        attention_mode: Attention computation backend ('sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
+        attention_mode: Attention computation backend ('sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
         debug: Debug instance for logging
         
     Returns:
@@ -774,7 +775,7 @@ def configure_runner(
         decode_tile_size: Tile size for decoding (height, width)
         decode_tile_overlap: Tile overlap for decoding (height, width)
         tile_debug: Tile visualization mode (false/encode/decode)
-        attention_mode: Attention computation backend ('sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
+        attention_mode: Attention computation backend ('sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
         torch_compile_args_dit: Optional torch.compile configuration for DiT model
         torch_compile_args_vae: Optional torch.compile configuration for VAE model
         
@@ -868,7 +869,7 @@ def _configure_runner_settings(
         decode_tile_size: Tile dimensions (height, width) for decoding in pixels
         decode_tile_overlap: Overlap dimensions (height, width) between decoding tiles
         tile_debug: Tile visualization mode (false/encode/decode)
-        attention_mode: Attention computation backend ('sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
+        attention_mode: Attention computation backend ('sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
         torch_compile_args_dit: torch.compile configuration for DiT model or None
         torch_compile_args_vae: torch.compile configuration for VAE model or None
         block_swap_config: BlockSwap configuration for DiT model or None
@@ -1196,7 +1197,15 @@ def apply_model_specific_config(model: torch.nn.Module, runner: VideoDiffusionIn
             
             # Get compute_dtype from runner
             compute_dtype = getattr(runner, '_compute_dtype', torch.bfloat16)            
-            debug.log(f"Applying {attention_mode} attention mode and {compute_dtype} compute dtype to model", category="setup")
+            if requested_attention_mode != attention_mode:
+                debug.log(
+                    f"Requested attention mode '{requested_attention_mode}' fell back to '{attention_mode}'",
+                    level="WARNING", category="setup", force=True
+                )
+            debug.log(
+                f"Using attention mode: {attention_mode} (requested={requested_attention_mode}, compute_dtype={compute_dtype})",
+                category="setup", force=True
+            )
             
             # Get the actual model (unwrap if needed)
             actual_model = model.dit_model if hasattr(model, 'dit_model') else model
@@ -1207,6 +1216,7 @@ def apply_model_specific_config(model: torch.nn.Module, runner: VideoDiffusionIn
                 if type(module).__name__ == 'FlashAttentionVarlen':
                     module.attention_mode = attention_mode
                     module.compute_dtype = compute_dtype
+                    module.debug = debug
                     updated_count += 1
             
             if updated_count > 0:

--- a/src/core/model_loader.py
+++ b/src/core/model_loader.py
@@ -123,6 +123,9 @@ def load_quantized_state_dict(checkpoint_path: str, device: torch.device = torch
             # MPS allocator fallback: some PyTorch/macOS versions have issues with
             # direct MPS loading (allocation failures, watermark errors, etc.)
             error_msg = str(e).lower()
+            is_xpu_alloc_error = device.type == "xpu" and any(
+                keyword in error_msg for keyword in ["watermark", "allocat", "memory"]
+            )
             is_mps_alloc_error = device.type == "mps" and any(
                 keyword in error_msg for keyword in ["watermark", "allocat", "memory"]
             )
@@ -134,6 +137,13 @@ def load_quantized_state_dict(checkpoint_path: str, device: torch.device = torch
                             category="info", indent_level=1)
                 state = load_safetensors_file(checkpoint_path, device="cpu")
                 # Tensors will be moved to MPS during model.load_state_dict()
+            elif is_xpu_alloc_error:
+                # Transparent fallback - only log if debug enabled
+                if debug:
+                    debug.log("Using CPU intermediate loading for XPU compatibility",
+                            category="info", indent_level=1)
+                state = load_safetensors_file(checkpoint_path, device="cpu")
+                # Tensors will be moved to XPU during model.load_state_dict()
             else:
                 # Re-raise if it's a different error (file corruption, etc.)
                 raise

--- a/src/data/image/transforms/area_resize.py
+++ b/src/data/image/transforms/area_resize.py
@@ -19,7 +19,7 @@ import torch
 from PIL import Image
 from torchvision.transforms import functional as TVF
 from torchvision.transforms.functional import InterpolationMode
-from ....optimization.memory_manager import is_mps_available
+from ....optimization.memory_manager import is_mps_available, is_xpu_available
 
 
 class AreaResize:
@@ -32,7 +32,7 @@ class AreaResize:
         self.max_area = max_area
         self.downsample_only = downsample_only
         self.interpolation = interpolation
-        if is_mps_available():
+        if is_mps_available() or is_xpu_available():
             self.interpolation = InterpolationMode.BILINEAR
 
     def __call__(self, image: Union[torch.Tensor, Image.Image]):
@@ -51,7 +51,7 @@ class AreaResize:
 
         resized_height, resized_width = round(height * scale), round(width * scale)
 
-        antialias = not (isinstance(image, torch.Tensor) and image.device.type == 'mps')
+        antialias = not (isinstance(image, torch.Tensor) and image.device.type in ('mps', 'xpu'))
         return TVF.resize(
             image,
             size=(resized_height, resized_width),
@@ -138,4 +138,3 @@ class ScaleResize:
             antialias=antialias,
         )
         return image
-    

--- a/src/data/image/transforms/na_resize.py
+++ b/src/data/image/transforms/na_resize.py
@@ -18,7 +18,7 @@ from torchvision.transforms import CenterCrop, Compose, InterpolationMode, Resiz
 
 from .area_resize import AreaResize
 from .side_resize import SideResize
-from ....optimization.memory_manager import is_mps_available
+from ....optimization.memory_manager import is_mps_available, is_xpu_available
 
 def NaResize(
     resolution: int,
@@ -27,7 +27,7 @@ def NaResize(
     max_resolution: int = 0,
     interpolation: InterpolationMode = InterpolationMode.BICUBIC,
 ):
-    Interpolation = InterpolationMode.BILINEAR if is_mps_available() else interpolation
+    Interpolation = InterpolationMode.BILINEAR if (is_mps_available() or is_xpu_available()) else interpolation
     if mode == "area":
         return AreaResize(
             max_area=resolution**2,

--- a/src/data/image/transforms/side_resize.py
+++ b/src/data/image/transforms/side_resize.py
@@ -17,7 +17,7 @@ import torch
 from PIL import Image
 from torchvision.transforms import InterpolationMode
 from torchvision.transforms import functional as TVF
-from ....optimization.memory_manager import is_mps_available
+from ....optimization.memory_manager import is_mps_available, is_xpu_available
 
 class SideResize:
     def __init__(
@@ -31,7 +31,7 @@ class SideResize:
         self.max_size = max_size
         self.downsample_only = downsample_only
         self.interpolation = interpolation
-        if is_mps_available():
+        if is_mps_available() or is_xpu_available():
             self.interpolation = InterpolationMode.BILINEAR
 
     def __call__(self, image: Union[torch.Tensor, Image.Image]):
@@ -57,8 +57,8 @@ class SideResize:
         else:
             size = self.size
 
-        # Resize to shortest edge (disable antialias only for MPS tensors - not supported)
-        antialias = not (isinstance(image, torch.Tensor) and image.device.type == 'mps')
+        # Resize to shortest edge (disable antialias only for MPS and XPU tensors - not supported)
+        antialias = not (isinstance(image, torch.Tensor) and image.device.type in ('mps', 'xpu'))
         resized = TVF.resize(image, size, self.interpolation, antialias=antialias)
         
         # Apply max_size constraint if specified

--- a/src/interfaces/dit_model_loader.py
+++ b/src/interfaces/dit_model_loader.py
@@ -102,19 +102,20 @@ class SeedVR2LoadDiTModel(io.ComfyNode):
                     )
                 ),
                 io.Combo.Input("attention_mode",
-                    options=["sdpa", "flash_attn_2", "flash_attn_3", "sageattn_2", "sageattn_3"],
+                    options=["sdpa", "omni_xpu", "flash_attn_2", "flash_attn_3", "sageattn_2", "sageattn_3"],
                     default="sdpa",
                     optional=True,
                     tooltip=(
                         "Attention computation backend:\n"
                         "• sdpa: PyTorch scaled_dot_product_attention (default, stable, always available)\n"
+                        "• omni_xpu: Intel Omni XPU SDP (Intel GPU, requires omni_xpu_kernel)\n"
                         "• flash_attn_2: Flash Attention 2 (Ampere+, requires flash-attn package)\n"
                         "• flash_attn_3: Flash Attention 3 (Hopper+, requires flash-attn with FA3 support)\n"
                         "• sageattn_2: SageAttention 2 (requires sageattention package)\n"
                         "• sageattn_3: SageAttention 3 (Blackwell/RTX 50xx only, requires sageattn3 package)\n"
                         "\n"
                         "SDPA is recommended - stable and works everywhere.\n"
-                        "Flash Attention and SageAttention provide speedup through optimized CUDA kernels on compatible GPUs."
+                        "Omni XPU, Flash Attention, and SageAttention provide speedup through optimized kernels on compatible GPUs."
                     )
                 ),
                 io.Custom("TORCH_COMPILE_ARGS").Input("torch_compile_args",
@@ -147,7 +148,7 @@ class SeedVR2LoadDiTModel(io.ComfyNode):
             cache_model: Whether to keep model loaded between runs
             blocks_to_swap: Number of transformer blocks to swap (requires offload_device != device)
             swap_io_components: Whether to offload I/O components (requires offload_device != device)
-            attention_mode: Attention computation backend ('sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
+            attention_mode: Attention computation backend ('sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3')
             torch_compile_args: Optional torch.compile configuration from settings node
             
         Returns:

--- a/src/interfaces/video_upscaler.py
+++ b/src/interfaces/video_upscaler.py
@@ -518,7 +518,7 @@ class SeedVR2VideoUpscaler(io.ComfyNode):
 
             # Ensure CPU tensor in float32 for maximum ComfyUI compatibility
             if torch.is_tensor(sample):
-                if sample.is_cuda or sample.is_mps:
+                if sample.is_cuda or sample.is_mps or sample.is_xpu:
                     sample = sample.cpu()
                 if sample.dtype != torch.float32:
                     src_dtype = sample.dtype

--- a/src/models/dit_3b/attention.py
+++ b/src/models/dit_3b/attention.py
@@ -14,14 +14,30 @@
 
 import torch
 import torch.nn.functional as F
+from collections import defaultdict
 
 # Import flash/sage attn with automatic fallback from compatibility layer
 from ...optimization.compatibility import (
     call_flash_attn_2_varlen, call_flash_attn_3_varlen,
-    call_sage_attn_2_varlen, call_sage_attn_3_varlen
+    call_sage_attn_2_varlen, call_sage_attn_3_varlen,
+    call_omni_xpu_sdp, OMNI_XPU_AVAILABLE
 )
 
 from torch import nn
+
+
+_OMNI_XPU_LOG_COUNTS = defaultdict(int)
+
+
+def _log_omni_xpu(debug, message: str, level: str = "INFO", category: str = "setup", limit: int = 1) -> None:
+    key = (level, message)
+    _OMNI_XPU_LOG_COUNTS[key] += 1
+    if _OMNI_XPU_LOG_COUNTS[key] > limit:
+        return
+    if debug is not None:
+        debug.log(message, level=level, category=category, force=True)
+    else:
+        print(f"[SeedVR2] {message}")
 
 
 def pytorch_varlen_attention(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q=None, max_seqlen_k=None, dropout_p=0.0, softmax_scale=None, causal=False, deterministic=False):
@@ -64,6 +80,97 @@ def pytorch_varlen_attention(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q=N
     return torch.cat(output_splits, dim=0)
 
 
+def omni_xpu_varlen_attention(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q=None, max_seqlen_k=None, dropout_p=0.0, softmax_scale=None, causal=False, deterministic=False, debug=None):
+    """
+    Intel Omni XPU SDP adapter for SeedVR2 varlen attention.
+
+    omni_xpu_kernel.sdp expects (batch, seq, heads, head_dim), while SeedVR2
+    varlen attention uses (total_seq, heads, head_dim). Process one packed
+    sequence at a time and fall back to PyTorch SDPA for unsupported cases.
+    """
+    fallback = lambda: pytorch_varlen_attention(
+        q, k, v, cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        deterministic=deterministic,
+    )
+
+    fallback_reason = None
+    if not OMNI_XPU_AVAILABLE:
+        fallback_reason = "omni_xpu_kernel SDP is not available"
+    elif q.device.type != "xpu" or k.device.type != "xpu" or v.device.type != "xpu":
+        fallback_reason = f"device q/k/v={q.device.type}/{k.device.type}/{v.device.type}"
+    elif q.dtype not in (torch.float16, torch.bfloat16) or not (q.dtype == k.dtype == v.dtype):
+        fallback_reason = f"dtype q/k/v={q.dtype}/{k.dtype}/{v.dtype}"
+    elif q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
+        fallback_reason = f"rank q/k/v={q.ndim}/{k.ndim}/{v.ndim}"
+    elif q.shape[1:] != k.shape[1:] or k.shape[1:] != v.shape[1:]:
+        fallback_reason = f"shape q/k/v={tuple(q.shape)}/{tuple(k.shape)}/{tuple(v.shape)}"
+    elif q.shape[-1] not in (64, 128):
+        fallback_reason = f"head_dim={q.shape[-1]}"
+    elif dropout_p not in (None, 0, 0.0):
+        fallback_reason = f"dropout_p={dropout_p}"
+    elif softmax_scale is not None:
+        fallback_reason = f"softmax_scale={softmax_scale}"
+    elif causal:
+        fallback_reason = "causal=True"
+
+    if fallback_reason is not None:
+        _log_omni_xpu(
+            debug,
+            f"OmniXPU attention fallback to SDPA: {fallback_reason}",
+            level="WARNING",
+            category="setup",
+            limit=3,
+        )
+        return fallback()
+
+    q_splits = list(torch.tensor_split(q, cu_seqlens_q[1:-1].long().cpu(), dim=0))
+    k_splits = list(torch.tensor_split(k, cu_seqlens_k[1:-1].long().cpu(), dim=0))
+    v_splits = list(torch.tensor_split(v, cu_seqlens_k[1:-1].long().cpu(), dim=0))
+
+    output_splits = []
+    try:
+        for q_i, k_i, v_i in zip(q_splits, k_splits, v_splits):
+            if q_i.shape[0] != k_i.shape[0] or k_i.shape[0] != v_i.shape[0]:
+                _log_omni_xpu(
+                    debug,
+                    f"OmniXPU attention fallback to SDPA: non-self attention lengths q/k/v={q_i.shape[0]}/{k_i.shape[0]}/{v_i.shape[0]}",
+                    level="WARNING",
+                    category="setup",
+                    limit=3,
+                )
+                return fallback()
+
+            _log_omni_xpu(
+                debug,
+                f"Using OmniXPU attention: seq={q_i.shape[0]}, heads={q_i.shape[1]}, head_dim={q_i.shape[2]}, dtype={q_i.dtype}",
+                category="success",
+                limit=1,
+            )
+            output_i = call_omni_xpu_sdp(
+                q_i.unsqueeze(0).contiguous(),
+                k_i.unsqueeze(0).contiguous(),
+                v_i.unsqueeze(0).contiguous(),
+            )
+            if isinstance(output_i, tuple):
+                output_i = output_i[0]
+            output_splits.append(output_i.squeeze(0))
+    except Exception as e:
+        _log_omni_xpu(
+            debug,
+            f"OmniXPU attention fallback to SDPA after runtime error: {str(e).splitlines()[0][:160]}",
+            level="WARNING",
+            category="setup",
+            limit=3,
+        )
+        return fallback()
+
+    return torch.cat(output_splits, dim=0)
+
+
 class TorchAttention(nn.Module):
     def tflops(self, args, kwargs, output) -> float:
         assert len(args) == 0 or len(args) > 2, "query, key should both provided by args / kwargs"
@@ -83,6 +190,7 @@ class FlashAttentionVarlen(nn.Module):
     
     Supported backends:
     - sdpa: PyTorch SDPA (fully compilable, always available)
+    - omni_xpu: Intel Omni XPU SDP (Intel XPU)
     - flash_attn_2: Flash Attention 2 (Ampere+)
     - flash_attn_3: Flash Attention 3 (Hopper+)
     - sageattn_2: SageAttention 2
@@ -96,12 +204,13 @@ class FlashAttentionVarlen(nn.Module):
         Initialize with specified attention backend.
         
         Args:
-            attention_mode: 'sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3'
+            attention_mode: 'sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3'
             compute_dtype: Compute dtype for attention (set by pipeline, defaults to None for auto-detection)
         """
         super().__init__()
         self.attention_mode = attention_mode
         self.compute_dtype = compute_dtype
+        self.debug = None
 
     def tflops(self, args, kwargs, output) -> float:
         cu_seqlens_q = kwargs["cu_seqlens_q"]
@@ -120,7 +229,12 @@ class FlashAttentionVarlen(nn.Module):
             k = k.to(self.compute_dtype)
             v = v.to(self.compute_dtype)
         
-        if self.attention_mode == 'flash_attn_3':
+        if self.attention_mode == 'omni_xpu':
+            return omni_xpu_varlen_attention(
+                q, k, v, cu_seqlens_q, cu_seqlens_k,
+                max_seqlen_q, max_seqlen_k, debug=getattr(self, "debug", None), **kwargs
+            )
+        elif self.attention_mode == 'flash_attn_3':
             return call_flash_attn_3_varlen(
                 q, k, v, cu_seqlens_q, cu_seqlens_k, 
                 max_seqlen_q, max_seqlen_k, **kwargs

--- a/src/models/dit_7b/attention.py
+++ b/src/models/dit_7b/attention.py
@@ -14,14 +14,30 @@
 
 import torch
 import torch.nn.functional as F
+from collections import defaultdict
 
 # Import flash/sage attn with automatic fallback from compatibility layer
 from ...optimization.compatibility import (
     call_flash_attn_2_varlen, call_flash_attn_3_varlen,
-    call_sage_attn_2_varlen, call_sage_attn_3_varlen
+    call_sage_attn_2_varlen, call_sage_attn_3_varlen,
+    call_omni_xpu_sdp, OMNI_XPU_AVAILABLE
 )
 
 from torch import nn
+
+
+_OMNI_XPU_LOG_COUNTS = defaultdict(int)
+
+
+def _log_omni_xpu(debug, message: str, level: str = "INFO", category: str = "setup", limit: int = 1) -> None:
+    key = (level, message)
+    _OMNI_XPU_LOG_COUNTS[key] += 1
+    if _OMNI_XPU_LOG_COUNTS[key] > limit:
+        return
+    if debug is not None:
+        debug.log(message, level=level, category=category, force=True)
+    else:
+        print(f"[SeedVR2] {message}")
 
 
 def pytorch_varlen_attention(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q=None, max_seqlen_k=None, dropout_p=0.0, softmax_scale=None, causal=False, deterministic=False):
@@ -64,6 +80,97 @@ def pytorch_varlen_attention(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q=N
     return torch.cat(output_splits, dim=0)
 
 
+def omni_xpu_varlen_attention(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q=None, max_seqlen_k=None, dropout_p=0.0, softmax_scale=None, causal=False, deterministic=False, debug=None):
+    """
+    Intel Omni XPU SDP adapter for SeedVR2 varlen attention.
+
+    omni_xpu_kernel.sdp expects (batch, seq, heads, head_dim), while SeedVR2
+    varlen attention uses (total_seq, heads, head_dim). Process one packed
+    sequence at a time and fall back to PyTorch SDPA for unsupported cases.
+    """
+    fallback = lambda: pytorch_varlen_attention(
+        q, k, v, cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        deterministic=deterministic,
+    )
+
+    fallback_reason = None
+    if not OMNI_XPU_AVAILABLE:
+        fallback_reason = "omni_xpu_kernel SDP is not available"
+    elif q.device.type != "xpu" or k.device.type != "xpu" or v.device.type != "xpu":
+        fallback_reason = f"device q/k/v={q.device.type}/{k.device.type}/{v.device.type}"
+    elif q.dtype not in (torch.float16, torch.bfloat16) or not (q.dtype == k.dtype == v.dtype):
+        fallback_reason = f"dtype q/k/v={q.dtype}/{k.dtype}/{v.dtype}"
+    elif q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
+        fallback_reason = f"rank q/k/v={q.ndim}/{k.ndim}/{v.ndim}"
+    elif q.shape[1:] != k.shape[1:] or k.shape[1:] != v.shape[1:]:
+        fallback_reason = f"shape q/k/v={tuple(q.shape)}/{tuple(k.shape)}/{tuple(v.shape)}"
+    elif q.shape[-1] not in (64, 128):
+        fallback_reason = f"head_dim={q.shape[-1]}"
+    elif dropout_p not in (None, 0, 0.0):
+        fallback_reason = f"dropout_p={dropout_p}"
+    elif softmax_scale is not None:
+        fallback_reason = f"softmax_scale={softmax_scale}"
+    elif causal:
+        fallback_reason = "causal=True"
+
+    if fallback_reason is not None:
+        _log_omni_xpu(
+            debug,
+            f"OmniXPU attention fallback to SDPA: {fallback_reason}",
+            level="WARNING",
+            category="setup",
+            limit=3,
+        )
+        return fallback()
+
+    q_splits = list(torch.tensor_split(q, cu_seqlens_q[1:-1].long().cpu(), dim=0))
+    k_splits = list(torch.tensor_split(k, cu_seqlens_k[1:-1].long().cpu(), dim=0))
+    v_splits = list(torch.tensor_split(v, cu_seqlens_k[1:-1].long().cpu(), dim=0))
+
+    output_splits = []
+    try:
+        for q_i, k_i, v_i in zip(q_splits, k_splits, v_splits):
+            if q_i.shape[0] != k_i.shape[0] or k_i.shape[0] != v_i.shape[0]:
+                _log_omni_xpu(
+                    debug,
+                    f"OmniXPU attention fallback to SDPA: non-self attention lengths q/k/v={q_i.shape[0]}/{k_i.shape[0]}/{v_i.shape[0]}",
+                    level="WARNING",
+                    category="setup",
+                    limit=3,
+                )
+                return fallback()
+
+            _log_omni_xpu(
+                debug,
+                f"Using OmniXPU attention: seq={q_i.shape[0]}, heads={q_i.shape[1]}, head_dim={q_i.shape[2]}, dtype={q_i.dtype}",
+                category="success",
+                limit=1,
+            )
+            output_i = call_omni_xpu_sdp(
+                q_i.unsqueeze(0).contiguous(),
+                k_i.unsqueeze(0).contiguous(),
+                v_i.unsqueeze(0).contiguous(),
+            )
+            if isinstance(output_i, tuple):
+                output_i = output_i[0]
+            output_splits.append(output_i.squeeze(0))
+    except Exception as e:
+        _log_omni_xpu(
+            debug,
+            f"OmniXPU attention fallback to SDPA after runtime error: {str(e).splitlines()[0][:160]}",
+            level="WARNING",
+            category="setup",
+            limit=3,
+        )
+        return fallback()
+
+    return torch.cat(output_splits, dim=0)
+
+
 class TorchAttention(nn.Module):
     def tflops(self, args, kwargs, output) -> float:
         assert len(args) == 0 or len(args) > 2, "query, key should both provided by args / kwargs"
@@ -83,6 +190,7 @@ class FlashAttentionVarlen(nn.Module):
     
     Supported backends:
     - sdpa: PyTorch SDPA (fully compilable, always available)
+    - omni_xpu: Intel Omni XPU SDP (Intel XPU)
     - flash_attn_2: Flash Attention 2 (Ampere+)
     - flash_attn_3: Flash Attention 3 (Hopper+)
     - sageattn_2: SageAttention 2
@@ -96,12 +204,13 @@ class FlashAttentionVarlen(nn.Module):
         Initialize with specified attention backend.
         
         Args:
-            attention_mode: 'sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3'
+            attention_mode: 'sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3'
             compute_dtype: Compute dtype for attention (set by pipeline, defaults to None for auto-detection)
         """
         super().__init__()
         self.attention_mode = attention_mode
         self.compute_dtype = compute_dtype
+        self.debug = None
 
     def tflops(self, args, kwargs, output) -> float:
         cu_seqlens_q = kwargs["cu_seqlens_q"]
@@ -120,7 +229,12 @@ class FlashAttentionVarlen(nn.Module):
             k = k.to(self.compute_dtype)
             v = v.to(self.compute_dtype)
         
-        if self.attention_mode == 'flash_attn_3':
+        if self.attention_mode == 'omni_xpu':
+            return omni_xpu_varlen_attention(
+                q, k, v, cu_seqlens_q, cu_seqlens_k,
+                max_seqlen_q, max_seqlen_k, debug=getattr(self, "debug", None), **kwargs
+            )
+        elif self.attention_mode == 'flash_attn_3':
             return call_flash_attn_3_varlen(
                 q, k, v, cu_seqlens_q, cu_seqlens_k, 
                 max_seqlen_q, max_seqlen_k, **kwargs

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -189,18 +189,53 @@ except (ImportError, AttributeError, OSError):
 
 SAGE_ATTN_AVAILABLE = SAGE_ATTN_2_AVAILABLE or SAGE_ATTN_3_AVAILABLE
 
+# 5. Intel Omni XPU SDP (XPU FlashAttention-style kernel)
+omni_xpu_sdp = None
+OMNI_XPU_AVAILABLE = False
+try:
+    import omni_xpu_kernel as _omni_xpu_kernel
+    from omni_xpu_kernel.sdp import sdp as _omni_xpu_sdp
+
+    if (
+        getattr(_omni_xpu_kernel, "is_available", lambda: False)()
+        and hasattr(torch, "xpu")
+        and torch.xpu.is_available()
+    ):
+        omni_xpu_sdp = _omni_xpu_sdp
+        OMNI_XPU_AVAILABLE = True
+except Exception:
+    pass
+
 
 def validate_attention_mode(requested_mode: str, debug=None) -> str:
     """
     Validate attention mode availability with automatic fallback.
     
     Args:
-        requested_mode: 'sdpa', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3'
+        requested_mode: 'sdpa', 'omni_xpu', 'flash_attn_2', 'flash_attn_3', 'sageattn_2', or 'sageattn_3'
         debug: Optional debug instance for logging
         
     Returns:
         Validated mode that is available
     """
+    # Intel Omni XPU SDP
+    if requested_mode == 'omni_xpu':
+        if OMNI_XPU_AVAILABLE:
+            return requested_mode
+        error_msg = (
+            "Cannot use 'omni_xpu' attention mode: omni_xpu_kernel SDP is not available.\n"
+            "\n"
+            "Omni XPU uses Intel XPU kernels for supported fp16/bf16 attention shapes.\n"
+            "Falling back to PyTorch SDPA (scaled dot-product attention).\n"
+            "\n"
+            "To fix this issue:\n"
+            "  1. Run repair_omni_xpu_after_update.bat from the ComfyUI portable folder\n"
+            "  2. OR change attention_mode to 'sdpa' (default, always available)"
+        )
+        if debug:
+            debug.log(error_msg, level="WARNING", category="setup", force=True)
+        return 'sdpa'
+
     # Flash Attention 3
     if requested_mode == 'flash_attn_3':
         if FLASH_ATTN_3_AVAILABLE:
@@ -563,6 +598,25 @@ def call_sage_attn_3_varlen(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, m
     return out.to(out_dtype) if out.dtype != out_dtype else out
 
 
+@torch._dynamo.disable
+def call_omni_xpu_sdp(q, k, v):
+    """
+    Wrapper for Intel Omni XPU SDP.
+
+    Args:
+        q: Query tensor (batch, seq, heads, head_dim)
+        k: Key tensor (batch, seq, heads, head_dim)
+        v: Value tensor (batch, seq, heads, head_dim)
+
+    Returns:
+        Attention output tensor (batch, seq, heads, head_dim)
+    """
+    if not OMNI_XPU_AVAILABLE or omni_xpu_sdp is None:
+        raise ImportError("Omni XPU SDP is not available")
+
+    return omni_xpu_sdp(q, k, v)
+
+
 # 2. Triton - Required for torch.compile with inductor backend
 try:
     import triton
@@ -661,29 +715,30 @@ NVIDIA_CONV3D_MEMORY_BUG_WORKAROUND = _check_conv3d_memory_bug()
 # Log all optimization status once globally (cross-process) using environment variable
 if not os.environ.get("SEEDVR2_OPTIMIZATIONS_LOGGED"):
     os.environ["SEEDVR2_OPTIMIZATIONS_LOGGED"] = "1"
-    
+
     # Build status strings
+    omni_status = "✅" if OMNI_XPU_AVAILABLE else "❌"
     sage_status = "✅" if SAGE_ATTN_AVAILABLE else "❌"
     flash_status = "✅" if FLASH_ATTN_AVAILABLE else "❌"
     triton_status = "✅" if TRITON_AVAILABLE else "❌"
-    
+
     # Count available optimizations
-    available = [SAGE_ATTN_AVAILABLE, FLASH_ATTN_AVAILABLE, TRITON_AVAILABLE]
+    available = [OMNI_XPU_AVAILABLE, SAGE_ATTN_AVAILABLE, FLASH_ATTN_AVAILABLE, TRITON_AVAILABLE]
     num_available = sum(available)
-    
-    if num_available == 3:
-        print(f"⚡ SeedVR2 optimizations check: SageAttention {sage_status} | Flash Attention {flash_status} | Triton {triton_status}")
-    elif num_available == 0:
-        print(f"⚠️  SeedVR2 optimizations check: SageAttention {sage_status} | Flash Attention {flash_status} | Triton {triton_status}")
-        print("💡 For best performance: pip install sageattention flash-attn triton")
+
+    icon = "⚡" if num_available > 0 else "⚠️ "
+    print(
+        f"{icon} SeedVR2 optimizations check: "
+        f"OmniXPU {omni_status} | "
+        f"SageAttention {sage_status} | "
+        f"Flash Attention {flash_status} | "
+        f"Triton {triton_status}"
+    )
+
+    if hasattr(torch, 'xpu') and torch.xpu.is_available():
+        if not OMNI_XPU_AVAILABLE:
+            print("💡 Intel XPU: run repair_omni_xpu_after_update.bat to enable OmniXPU attention.")
     else:
-        icon = "⚡" if num_available >= 2 else "⚠️ "
-        if hasattr(torch, 'xpu') and torch.xpu.is_available():
-            print(f"⚡ SeedVR2 optimizations check: Triton {triton_status}")
-        else:
-            print(f"{icon} SeedVR2 optimizations check: SageAttention {sage_status} | Flash Attention {flash_status} | Triton {triton_status}")
-        
-        # Build install suggestions for missing packages
         missing = []
         if not SAGE_ATTN_AVAILABLE:
             missing.append("sageattention")
@@ -693,7 +748,7 @@ if not os.environ.get("SEEDVR2_OPTIMIZATIONS_LOGGED"):
             missing.append("triton")
         if missing:
             print(f"💡 Optional: pip install {' '.join(missing)}")
-    
+
     # Conv3d workaround status (if applicable)
     if NVIDIA_CONV3D_MEMORY_BUG_WORKAROUND:
         torch_ver = torch.__version__.split('+')[0]

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -56,6 +56,23 @@ def ensure_flash_attn_safe():
         sys.modules['flash_attn'] = stub
 
 
+def ensure_transformers_flash_attn_mapping_safe():
+    """
+    Transformers 5.x may raise KeyError while checking optional flash_attn
+    packages if the distribution mapping lacks flash attention entries.
+    SeedVR2 can run with SDPA, so the optional check should resolve to False
+    rather than aborting plugin import.
+    """
+    try:
+        from transformers.utils import import_utils
+        mapping = getattr(import_utils, "PACKAGE_DISTRIBUTION_MAPPING", None)
+        if isinstance(mapping, dict):
+            mapping.setdefault("flash_attn", ["flash-attn"])
+            mapping.setdefault("flash_attn_interface", ["flash-attn-3"])
+    except Exception:
+        pass
+
+
 def ensure_xformers_flash_compat():
     """
     Pre-test xformers._C_flashattention; stub if DLL is broken.
@@ -111,6 +128,7 @@ def ensure_bitsandbytes_safe():
 # Run all shims immediately on import, before torch/diffusers
 ensure_triton_compat()
 ensure_flash_attn_safe()
+ensure_transformers_flash_attn_mapping_safe()
 ensure_xformers_flash_compat()
 ensure_bitsandbytes_safe()
 

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -678,7 +678,10 @@ if not os.environ.get("SEEDVR2_OPTIMIZATIONS_LOGGED"):
         print("💡 For best performance: pip install sageattention flash-attn triton")
     else:
         icon = "⚡" if num_available >= 2 else "⚠️ "
-        print(f"{icon} SeedVR2 optimizations check: SageAttention {sage_status} | Flash Attention {flash_status} | Triton {triton_status}")
+        if hasattr(torch, 'xpu') and torch.xpu.is_available():
+            print(f"⚡ SeedVR2 optimizations check: Triton {triton_status}")
+        else:
+            print(f"{icon} SeedVR2 optimizations check: SageAttention {sage_status} | Flash Attention {flash_status} | Triton {triton_status}")
         
         # Build install suggestions for missing packages
         missing = []
@@ -816,6 +819,8 @@ class CompatibleDiT(torch.nn.Module):
                     if module.rope.freqs.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
                         if module.rope.freqs.device.type == "mps":
                             module.rope.freqs.data = module.rope.freqs.to("cpu").to(target_dtype).to("mps")
+                        elif module.rope.freqs.device.type == "xpu":
+                            module.rope.freqs.data = module.rope.freqs.to("cpu").to(target_dtype).to("xpu")
                         else:
                             module.rope.freqs.data = module.rope.freqs.to(target_dtype)
                         converted += 1
@@ -841,6 +846,11 @@ class CompatibleDiT(torch.nn.Module):
                     temp_converted = temp_cpu.to(target_dtype)
                     param.data = temp_converted.to("mps")
                     del temp_cpu, temp_converted
+                elif param.device.type == "xpu":
+                    temp_cpu = param.data.to("cpu")
+                    temp_converted = temp_cpu.to(target_dtype)
+                    param.data = temp_converted.to("xpu")
+                    del temp_cpu, temp_converted
                 else:
                     param.data = param.data.to(target_dtype)
                 converted_count += 1
@@ -855,6 +865,11 @@ class CompatibleDiT(torch.nn.Module):
                     temp_cpu = buffer.data.to("cpu")
                     temp_converted = temp_cpu.to(target_dtype)
                     buffer.data = temp_converted.to("mps")
+                    del temp_cpu, temp_converted
+                elif buffer.device.type == "xpu":
+                    temp_cpu = buffer.data.to("cpu")
+                    temp_converted = temp_cpu.to(target_dtype)
+                    buffer.data = temp_converted.to("xpu")
                     del temp_cpu, temp_converted
                 else:
                     buffer.data = buffer.data.to(target_dtype)

--- a/src/optimization/memory_manager.py
+++ b/src/optimization/memory_manager.py
@@ -30,6 +30,11 @@ def is_cuda_available() -> bool:
     return torch.cuda.is_available()
 
 
+def is_xpu_available() -> bool:
+    """Check if Intel XPU backend is available."""
+    return hasattr(torch, 'xpu') and torch.xpu.is_available()
+
+
 def get_gpu_backend() -> str:
     """Get the active GPU backend type.
     
@@ -40,6 +45,8 @@ def get_gpu_backend() -> str:
     """
     if is_cuda_available():
         return 'cuda'
+    if is_xpu_available():
+        return 'xpu'
     if is_mps_available():
         return 'mps'
     return 'cpu'
@@ -61,11 +68,20 @@ def get_device_list(include_none: bool = False, include_cpu: bool = False) -> Li
     devs = []
     has_cuda = False
     has_mps = False
+    has_xpu = False
     
     try:
         if is_cuda_available():
             devs += [f"cuda:{i}" for i in range(torch.cuda.device_count())]
             has_cuda = True
+    except Exception:
+        pass
+
+    try:
+        if is_xpu_available():
+            device_count = torch.xpu.device_count() if hasattr(torch.xpu, 'device_count') else 1
+            devs += [f"xpu:{i}" for i in range(device_count)]
+            has_xpu = True
     except Exception:
         pass
     
@@ -86,7 +102,7 @@ def get_device_list(include_none: bool = False, include_cpu: bool = False) -> Li
     # 2. Either CUDA is available OR MPS is not the only option
     # Rationale: On MPS-only systems with unified memory architecture,
     # CPU offloading is semantically meaningless as CPU and GPU share the same memory pool
-    if include_cpu and (has_cuda or not has_mps):
+    if include_cpu and (has_cuda or has_xpu or not has_mps):
         result.append("cpu")
     
     result.extend(devs)
@@ -112,6 +128,12 @@ def get_basic_vram_info(device: Optional[torch.device] = None) -> Dict[str, Any]
             elif not isinstance(device, torch.device):
                 device = torch.device(device)
             free_memory, total_memory = torch.cuda.mem_get_info(device)
+        elif is_xpu_available():
+            # Intel iGPUs use shared memory. PyTorch XPU does not expose CUDA-like
+            # mem_get_info on all builds, so system memory is the safest proxy.
+            mem = psutil.virtual_memory()
+            free_memory = mem.available
+            total_memory = mem.total
         elif is_mps_available():
             # MPS doesn't support per-device queries or mem_get_info
             # Use system memory as proxy
@@ -132,7 +154,7 @@ def get_basic_vram_info(device: Optional[torch.device] = None) -> Dict[str, Any]
 # Initial VRAM check at module load
 vram_info = get_basic_vram_info(device=None)
 if "error" not in vram_info:
-    backend = "MPS" if is_mps_available() else "CUDA"
+    backend = "XPU" if is_xpu_available() else ("MPS" if is_mps_available() else "CUDA")
     print(f"📊 Initial {backend} memory: {vram_info['free_gb']:.2f}GB free / {vram_info['total_gb']:.2f}GB total")
 else:
     print(f"⚠️ Memory check failed: {vram_info['error']} - No available backend!")
@@ -161,6 +183,16 @@ def get_vram_usage(device: Optional[torch.device] = None, debug: Optional['Debug
             reserved = torch.cuda.memory_reserved(device) / (1024**3)
             peak_allocated = torch.cuda.max_memory_allocated(device) / (1024**3)
             peak_reserved = torch.cuda.max_memory_reserved(device) / (1024**3)
+            return allocated, reserved, peak_allocated, peak_reserved
+        elif is_xpu_available():
+            if device is None:
+                device = torch.device("xpu:0")
+            elif not isinstance(device, torch.device):
+                device = torch.device(device)
+            allocated = torch.xpu.memory_allocated(device) / (1024**3) if hasattr(torch.xpu, 'memory_allocated') else 0.0
+            reserved = torch.xpu.memory_reserved(device) / (1024**3) if hasattr(torch.xpu, 'memory_reserved') else 0.0
+            peak_allocated = torch.xpu.max_memory_allocated(device) / (1024**3) if hasattr(torch.xpu, 'max_memory_allocated') else allocated
+            peak_reserved = torch.xpu.max_memory_reserved(device) / (1024**3) if hasattr(torch.xpu, 'max_memory_reserved') else reserved
             return allocated, reserved, peak_allocated, peak_reserved
         elif is_mps_available():
             # MPS doesn't support per-device queries - uses global memory tracking
@@ -298,6 +330,8 @@ def clear_memory(debug: Optional['Debug'] = None, deep: bool = False, force: boo
     if is_cuda_available():
         torch.cuda.empty_cache()
         torch.cuda.ipc_collect()
+    elif is_xpu_available():
+        torch.xpu.empty_cache()
     elif is_mps_available():
         torch.mps.empty_cache()
     
@@ -418,6 +452,12 @@ def reset_vram_peak(device: Optional[torch.device] = None, debug: Optional['Debu
             elif not isinstance(device, torch.device):
                 device = torch.device(device)
             torch.cuda.reset_peak_memory_stats(device)
+        elif is_xpu_available() and hasattr(torch.xpu, 'reset_peak_memory_stats'):
+            if device is None:
+                device = torch.device("xpu:0")
+            elif not isinstance(device, torch.device):
+                device = torch.device(device)
+            torch.xpu.reset_peak_memory_stats(device)
         # Note: MPS doesn't support peak memory reset - no action needed
     except Exception as e:
         if debug and debug.enabled:

--- a/src/optimization/memory_manager.py
+++ b/src/optimization/memory_manager.py
@@ -15,9 +15,13 @@ from typing import Tuple, Dict, Any, Optional, List, Union
 
 
 def _device_str(device: Union[torch.device, str]) -> str:
-    """Normalized uppercase device string for comparison and logging. MPS variants → 'MPS'."""
+    """Normalized uppercase device string for comparison and logging."""
     s = str(device).upper()
-    return 'MPS' if s.startswith('MPS') else s
+    if s.startswith('MPS'):
+        return 'MPS'
+    if s.startswith('XPU'):
+        return 'XPU'
+    return s
 
 
 def is_mps_available() -> bool:
@@ -141,7 +145,7 @@ def get_basic_vram_info(device: Optional[torch.device] = None) -> Dict[str, Any]
             free_memory = mem.total - mem.used
             total_memory = mem.total
         else:
-            return {"error": "No GPU backend available (CUDA/MPS)"}
+            return {"error": "No GPU backend available (CUDA/MPS/XPU)"}
         
         return {
             "free_gb": free_memory / (1024**3),
@@ -300,7 +304,7 @@ def clear_memory(debug: Optional['Debug'] = None, deep: bool = False, force: boo
             if free_ratio < 0.05:
                 should_clear = True
                 if debug:
-                    backend = "Unified Memory" if is_mps_available() else "VRAM"
+                    backend = "XPU" if is_xpu_available() else ("Unified Memory" if is_mps_available() else "VRAM")
                     debug.log(f"{backend} pressure: {mem_info['free_gb']:.2f}GB free of {mem_info['total_gb']:.2f}GB", category="memory")
         
         # For non-MPS systems, also check system RAM separately
@@ -601,14 +605,14 @@ def release_model_memory(model: Optional[torch.nn.Module], debug: Optional['Debu
         released_buffers = 0
         
         for param in model.parameters():
-            if param.is_cuda or param.is_mps:
+            if param.is_cuda or param.is_mps or param.is_xpu:
                 if param.numel() > 0:
                     param.data.set_()
                     released_params += 1
                 param.grad = None
                 
         for buffer in model.buffers():
-            if buffer.is_cuda or buffer.is_mps:
+            if buffer.is_cuda or buffer.is_mps or buffer.is_xpu:
                 if buffer.numel() > 0:
                     buffer.data.set_()
                     released_buffers += 1
@@ -806,7 +810,7 @@ def _handle_blockswap_model_movement(runner: Any, model: torch.nn.Module,
         # Check if any parameter is on GPU (for accurate logging)
         actual_source_device = None
         for param in model.parameters():
-            if param.device.type in ['cuda', 'mps']:
+            if param.device.type in ['cuda', 'mps', 'xpu']:
                 actual_source_device = param.device
                 break
         
@@ -956,7 +960,7 @@ def _standard_model_movement(model: torch.nn.Module, current_device: torch.devic
         cleared_count = 0
         for module in model.modules():
             if hasattr(module, 'memory') and module.memory is not None:
-                if torch.is_tensor(module.memory) and (module.memory.is_cuda or module.memory.is_mps):
+                if torch.is_tensor(module.memory) and (module.memory.is_cuda or module.memory.is_mps or module.memory.is_xpu):
                     module.memory = None
                     cleared_count += 1
         if cleared_count > 0 and debug:

--- a/src/utils/debug.py
+++ b/src/utils/debug.py
@@ -214,12 +214,12 @@ class Debug:
             gpu_str = "CPU"
             cudnn_ver = "N/A"
         
-        # Flash Attn, SageAttn & Triton - reuse existing module constants
+        # Attention and compiler backend status - reuse existing module constants
         try:
             from ..optimization.compatibility import (
                 FLASH_ATTN_2_AVAILABLE, FLASH_ATTN_3_AVAILABLE,
                 SAGE_ATTN_2_AVAILABLE, SAGE_ATTN_3_AVAILABLE,
-                TRITON_AVAILABLE
+                TRITON_AVAILABLE, OMNI_XPU_AVAILABLE
             )
             fa_parts = []
             if FLASH_ATTN_3_AVAILABLE:
@@ -235,9 +235,10 @@ class Debug:
                 sa_parts.append("2")
             sage_str = f"v{','.join(sa_parts)} ✓" if sa_parts else "✗"
             
+            omni_xpu_str = "✓" if OMNI_XPU_AVAILABLE else "✗"
             triton_str = "✓" if TRITON_AVAILABLE else "✗"
         except ImportError:
-            flash_str = sage_str = triton_str = "?"
+            flash_str = sage_str = omni_xpu_str = triton_str = "?"
         
         # ComfyUI version
         comfy_str = None
@@ -250,7 +251,7 @@ class Debug:
         
         # Print
         self.log(f"OS: {os_str} | GPU: {gpu_str}", category="info")
-        self.log(f"Python: {py_ver} | PyTorch: {torch_ver} | FlashAttn: {flash_str} | SageAttn: {sage_str} | Triton: {triton_str}", category="info")
+        self.log(f"Python: {py_ver} | PyTorch: {torch_ver} | OmniXPU: {omni_xpu_str} | FlashAttn: {flash_str} | SageAttn: {sage_str} | Triton: {triton_str}", category="info")
         cuda_line = f"CUDA: {cuda_ver} | cuDNN: {cudnn_ver}"
         self.log(f"{cuda_line} | ComfyUI: {comfy_str}" if comfy_str else cuda_line, category="info")
         self.log("", category="none")


### PR DESCRIPTION
## Summary

Adds experimental Intel XPU backend discovery and memory-management support so SeedVR2 nodes can load on PyTorch XPU systems.

Changes:
- Detect `torch.xpu` devices and expose them as `xpu:0`, `xpu:1`, etc. in SeedVR2 device dropdowns.
- Report XPU as the active backend from `get_gpu_backend()`.
- Use system memory as a conservative shared-memory proxy for XPU/iGPU memory checks.
- Add XPU memory usage, cache clearing, and peak reset hooks when available.
- Add a small Transformers 5.x flash-attn mapping guard so optional flash-attn checks fail closed instead of aborting import when flash-attn is not installed.

## Local validation

Tested on Windows portable ComfyUI with PyTorch `2.12.0+xpu` on Intel Core Ultra x7 358H / Intel XPU.

Validated:
- ComfyUI extension entrypoint loads successfully.
- Node schemas build for:
  - `SeedVR2VideoUpscaler`
  - `SeedVR2LoadDiTModel`
  - `SeedVR2LoadVAEModel`
  - `SeedVR2TorchCompileSettings`
- Device list returns `['xpu:0']` and offload list returns `['none', 'cpu', 'xpu:0']`.
- Inference smoke tests completed with:
  - DiT: `seedvr2_ema_7b-Q8_0.gguf`
  - VAE: `ema_vae_fp16.safetensors`
  - device: `xpu:0`
  - attention: `sdpa`
  - single image 768x768 -> 1080x1080
  - single image 1280x720 -> 3640x2048 with tiled VAE encode/decode

This is intended as experimental support. It does not add CUDA-only attention backends for XPU.