### PR TITLE
Yet another nvfp4 model loader

### DIFF
--- a/src/core/model_loader.py
+++ b/src/core/model_loader.py
@@ -76,9 +76,18 @@ if GGUF_AVAILABLE:
     from ..optimization.gguf_ops import replace_linear_with_quantized
 
 from ..utils.constants import get_script_directory, suppress_tensor_warnings
+from ..optimization.nvfp4_loader import (
+    is_nvfp4_checkpoint,
+    is_nvfp4_state_dict,
+    load_nvfp4_model_weights,
+    prepare_nvfp4_state_dict,
+    read_safetensors_metadata,
+)
 
 # Get script directory for config paths
 script_directory = get_script_directory()
+
+_QUANT_STATE_SUFFIXES = (".weight_scale", ".weight_scale_2", ".input_scale", ".comfy_quant")
 
 
 def load_quantized_state_dict(checkpoint_path: str, device: torch.device = torch.device("cpu"),
@@ -102,7 +111,8 @@ def load_quantized_state_dict(checkpoint_path: str, device: torch.device = torch
         - PyTorch files use memory-mapped loading to reduce RAM usage
     """
     device_str = str(device)
-    
+    safetensors_metadata = {}
+
     if checkpoint_path.endswith('.safetensors'):
         if not SAFETENSORS_AVAILABLE:
             error_msg = (
@@ -115,6 +125,8 @@ def load_quantized_state_dict(checkpoint_path: str, device: torch.device = torch
                 debug.log("This is a one-time installation that will enable loading of .safetensors files", 
                          level="INFO", category="info", force=True)
             raise ImportError(error_msg)
+
+        safetensors_metadata = read_safetensors_metadata(checkpoint_path)
         
         # Try direct device loading first (optimal path)
         try:
@@ -137,6 +149,15 @@ def load_quantized_state_dict(checkpoint_path: str, device: torch.device = torch
             else:
                 # Re-raise if it's a different error (file corruption, etc.)
                 raise
+
+        if is_nvfp4_checkpoint(checkpoint_path, state):
+            if debug:
+                debug.log(
+                    "Detected NVFP4 checkpoint - using ComfyUI mixed precision loading",
+                    category="dit",
+                    force=True,
+                )
+            state = prepare_nvfp4_state_dict(state, safetensors_metadata)
     elif checkpoint_path.endswith('.gguf'):
         validate_gguf_availability(f"load {os.path.basename(checkpoint_path)}", debug)
         state = _load_gguf_state(
@@ -590,7 +611,16 @@ def _load_model_weights(model: torch.nn.Module, checkpoint_path: str, target_dev
     if checkpoint_path.endswith('.gguf'):
         model = _load_gguf_weights(model, state, used_meta, model_type_lower, debug)
     else:
-        model = _load_standard_weights(model, state, used_meta, model_type, model_type_lower, debug)
+        model = _load_standard_weights(
+            model,
+            state,
+            used_meta,
+            model_type,
+            model_type_lower,
+            debug,
+            target_device=target_device,
+            override_dtype=override_dtype,
+        )
     
     # Clean up state dict
     del state
@@ -609,6 +639,8 @@ def _convert_state_dtype(state: Dict[str, torch.Tensor], target_dtype: torch.dty
     debug.start_timer(f"{model_type.lower()}_dtype_convert")
     
     for key in state:
+        if any(key.endswith(suffix) for suffix in _QUANT_STATE_SUFFIXES):
+            continue
         if torch.is_tensor(state[key]) and state[key].is_floating_point():
             state[key] = state[key].to(target_dtype)
     
@@ -817,10 +849,17 @@ def initialize_meta_buffers_impl(model: torch.nn.Module, target_device: torch.de
 
 def _load_standard_weights(model: torch.nn.Module, state: Dict[str, torch.Tensor], 
                           used_meta: bool, model_type: str, model_type_lower: str,
-                          debug: Optional['Debug'] = None) -> torch.nn.Module:
+                          debug: Optional['Debug'] = None,
+                          target_device: Optional[torch.device] = None,
+                          override_dtype: Optional[torch.dtype] = None) -> torch.nn.Module:
     """Load standard (non-GGUF) weights into model."""
     debug.start_timer(f"{model_type_lower}_state_apply")
-    model.load_state_dict(state, strict=False, assign=True)
+    if is_nvfp4_state_dict(state):
+        compute_dtype = override_dtype or torch.bfloat16
+        load_device = target_device or torch.device("cpu")
+        model, _ = load_nvfp4_model_weights(model, state, compute_dtype, load_device, debug)
+    else:
+        model.load_state_dict(state, strict=False, assign=True)
     
     action = "materialized" if used_meta else "applied"
     debug.end_timer(f"{model_type_lower}_state_apply", f"{model_type} weights {action}")

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -118,6 +118,8 @@ ensure_bitsandbytes_safe()
 import torch
 import os
 
+from .nvfp4_loader import model_has_nvfp4_layers
+
 
 # Flash/Sage Attention & Triton Compatibility Layer
 
@@ -741,6 +743,7 @@ class CompatibleDiT(torch.nn.Module):
         self.model_dtype = self._detect_model_dtype()
         self.is_fp8_model = self.model_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
         self.is_fp16_model = self.model_dtype == torch.float16
+        self.is_nvfp4_model = getattr(dit_model, "_seedvr2_nvfp4", False) or model_has_nvfp4_layers(dit_model)
 
         # Only convert if not already done (e.g., when reusing cached weights)
         if not skip_conversion and self.is_fp8_model:
@@ -770,8 +773,17 @@ class CompatibleDiT(torch.nn.Module):
     def _detect_model_dtype(self) -> torch.dtype:
         """Detect main model dtype"""
         try:
-            return next(self.dit_model.parameters()).dtype
-        except:
+            for param in self.dit_model.parameters():
+                if param.dtype in (
+                    torch.float32,
+                    torch.float16,
+                    torch.bfloat16,
+                    torch.float8_e4m3fn,
+                    torch.float8_e5m2,
+                ):
+                    return param.dtype
+            return self.compute_dtype
+        except Exception:
             return torch.bfloat16
     
     def _get_model_variant(self) -> str:
@@ -899,26 +911,29 @@ class CompatibleDiT(torch.nn.Module):
         Conversion strategy:
             - FP16/BFloat16/Float32 models: Use native precision (no conversion needed)
             - FP8 models: Convert FP8 tensors to compute_dtype for arithmetic operations
+            - NVFP4 models: Convert FP32 activations to compute_dtype (NVFP4 kernels require FP16/BF16)
             (FP8 parameters stay in FP8 for memory efficiency, only converted for computation)
         """
         
-        # Only convert if we have an FP8 model for arithmetic operations 
-        if self.is_fp8_model:
-            fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
-            target_dtype = self.compute_dtype
-            
-            # Convert args
+        fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+        target_dtype = self.compute_dtype
+        needs_conversion = self.is_fp8_model or self.is_nvfp4_model
+
+        if needs_conversion:
             converted_args = []
             for arg in args:
                 if isinstance(arg, torch.Tensor) and arg.dtype in fp8_dtypes:
                     converted_args.append(arg.to(target_dtype))
+                elif isinstance(arg, torch.Tensor) and self.is_nvfp4_model and arg.dtype == torch.float32:
+                    converted_args.append(arg.to(target_dtype))
                 else:
                     converted_args.append(arg)
             
-            # Convert kwargs
             converted_kwargs = {}
             for key, value in kwargs.items():
                 if isinstance(value, torch.Tensor) and value.dtype in fp8_dtypes:
+                    converted_kwargs[key] = value.to(target_dtype)
+                elif isinstance(value, torch.Tensor) and self.is_nvfp4_model and value.dtype == torch.float32:
                     converted_kwargs[key] = value.to(target_dtype)
                 else:
                     converted_kwargs[key] = value
@@ -926,26 +941,31 @@ class CompatibleDiT(torch.nn.Module):
             args = tuple(converted_args)
             kwargs = converted_kwargs
         
-        # Execute forward pass
         try:
+            if self.is_nvfp4_model and self.compute_dtype in (torch.float16, torch.bfloat16):
+                device_type = args[0].device.type if args and isinstance(args[0], torch.Tensor) else "cuda"
+                with torch.autocast(device_type=device_type, dtype=self.compute_dtype, enabled=True):
+                    return self.dit_model(*args, **kwargs)
             return self.dit_model(*args, **kwargs)
         except Exception as e:
             self.debug.log(f"Forward pass error: {e}", level="ERROR", category="generation", force=True)
             if self.is_fp8_model:
                 self.debug.log(f"FP8 model - converted FP8 tensors to {self.compute_dtype}", category="info", force=True)
+            elif self.is_nvfp4_model:
+                self.debug.log(f"NVFP4 model - compute dtype is {self.compute_dtype}", category="info", force=True)
             else:
                 self.debug.log(f"{self.model_dtype} model - no conversion applied", category="info", force=True)
             raise
     
     def __getattr__(self, name):
         """Redirect all other attributes to original model"""
-        if name in ['dit_model', 'model_dtype', 'is_fp8_model', 'is_fp16_model']:
+        if name in ['dit_model', 'model_dtype', 'is_fp8_model', 'is_fp16_model', 'is_nvfp4_model']:
             return super().__getattr__(name)
         return getattr(self.dit_model, name)
     
     def __setattr__(self, name, value):
         """Redirect assignments to original model except for our attributes"""
-        if name in ['dit_model', 'model_dtype', 'is_fp8_model', 'is_fp16_model']:
+        if name in ['dit_model', 'model_dtype', 'is_fp8_model', 'is_fp16_model', 'is_nvfp4_model']:
             super().__setattr__(name, value)
         else:
             if hasattr(self, 'dit_model'):

--- a/src/optimization/nvfp4_loader.py
+++ b/src/optimization/nvfp4_loader.py
@@ -1,0 +1,181 @@
+"""
+NVFP4 checkpoint loading via ComfyUI mixed_precision_ops.
+
+ComfyUI NVFP4 weights store packed uint8 tensors with half the in_features
+dimension plus weight_scale / weight_scale_2 metadata. Plain nn.Linear cannot
+load them; MixedPrecisionOps.Linear handles the packed layout via comfy_quant.
+"""
+
+import json
+import os
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+try:
+    import comfy.model_management
+    import comfy.ops
+    import comfy.utils
+    COMFY_QUANT_AVAILABLE = True
+except ImportError:
+    COMFY_QUANT_AVAILABLE = False
+
+try:
+    from safetensors import safe_open
+    SAFETENSORS_METADATA_AVAILABLE = True
+except ImportError:
+    SAFETENSORS_METADATA_AVAILABLE = False
+
+
+def read_safetensors_metadata(checkpoint_path: str) -> Dict[str, str]:
+    if not checkpoint_path.endswith(".safetensors") or not SAFETENSORS_METADATA_AVAILABLE:
+        return {}
+    try:
+        with safe_open(checkpoint_path, framework="pt") as handle:
+            return handle.metadata() or {}
+    except Exception:
+        return {}
+
+
+def is_nvfp4_checkpoint(checkpoint_path: str, state: Optional[Dict[str, torch.Tensor]] = None) -> bool:
+    filename = os.path.basename(checkpoint_path).lower()
+    if "nvfp4" in filename or "_fp4" in filename:
+        return True
+
+    metadata = read_safetensors_metadata(checkpoint_path)
+    if metadata:
+        metadata_text = str(metadata).lower()
+        if "nvfp4" in metadata_text or metadata.get("quantization") == "nvfp4":
+            return True
+        if "_quantization_metadata" in metadata:
+            return True
+
+    if state is not None and is_nvfp4_state_dict(state):
+        return True
+
+    return False
+
+
+def is_nvfp4_state_dict(state: Dict[str, torch.Tensor]) -> bool:
+    if any(key.endswith(".comfy_quant") for key in state):
+        return True
+    if any(key.endswith(".weight_scale_2") for key in state):
+        return True
+    return False
+
+
+def _inject_comfy_quant_from_scale_keys(state: Dict[str, torch.Tensor]) -> None:
+    for key in list(state.keys()):
+        if not key.endswith(".weight_scale_2"):
+            continue
+        layer = key[: -len(".weight_scale_2")]
+        weight_key = f"{layer}.weight"
+        quant_key = f"{layer}.comfy_quant"
+        if weight_key not in state or quant_key in state:
+            continue
+        conf = json.dumps({"format": "nvfp4"})
+        state[quant_key] = torch.tensor(list(conf.encode("utf-8")), dtype=torch.uint8)
+
+
+def prepare_nvfp4_state_dict(
+    state: Dict[str, torch.Tensor],
+    metadata: Optional[Dict[str, str]] = None,
+) -> Dict[str, torch.Tensor]:
+    if not COMFY_QUANT_AVAILABLE:
+        return state
+
+    metadata = metadata or {}
+    state, _metadata = comfy.utils.convert_old_quants(state, model_prefix="", metadata=metadata)
+    if not is_nvfp4_state_dict(state):
+        _inject_comfy_quant_from_scale_keys(state)
+    return state
+
+
+def model_has_nvfp4_layers(module: nn.Module) -> bool:
+    for child in module.modules():
+        if getattr(child, "quant_format", None) == "nvfp4":
+            return True
+        if getattr(child, "layout_type", None) == "TensorCoreNVFP4Layout":
+            return True
+    return False
+
+
+def _patch_nvfp4_linear_forward(linear: nn.Module, compute_dtype: torch.dtype) -> None:
+    if getattr(linear, "_nvfp4_input_dtype_patched", False):
+        return
+
+    original_forward = linear.forward
+
+    def forward(input, *args, **kwargs):
+        if torch.is_tensor(input) and input.dtype == torch.float32:
+            input = input.to(compute_dtype)
+        return original_forward(input, *args, **kwargs)
+
+    linear.forward = forward
+    linear._nvfp4_input_dtype_patched = True
+
+
+def replace_linear_with_mixed_precision(
+    module: nn.Module,
+    compute_dtype: torch.dtype,
+    layer_device: torch.device,
+) -> int:
+    if not COMFY_QUANT_AVAILABLE:
+        raise RuntimeError(
+            "NVFP4 checkpoint requires ComfyUI quantization support (comfy.ops / comfy.utils)."
+        )
+
+    disabled = []
+    if layer_device.type == "cuda" and not comfy.model_management.supports_nvfp4_compute(layer_device):
+        disabled.append("nvfp4")
+
+    ops = comfy.ops.mixed_precision_ops(compute_dtype=compute_dtype, disabled=disabled)
+    replacements = 0
+
+    for name, child in list(module.named_children()):
+        if isinstance(child, nn.Linear):
+            new_linear = ops.Linear(
+                child.in_features,
+                child.out_features,
+                bias=child.bias is not None,
+                device=layer_device,
+                dtype=compute_dtype,
+            )
+            _patch_nvfp4_linear_forward(new_linear, compute_dtype)
+            setattr(module, name, new_linear)
+            replacements += 1
+        else:
+            replacements += replace_linear_with_mixed_precision(child, compute_dtype, layer_device)
+
+    return replacements
+
+
+def _resolve_layer_device(model: nn.Module, load_device: torch.device) -> torch.device:
+    try:
+        model_device = next(model.parameters()).device
+    except StopIteration:
+        return load_device
+    if model_device.type == "meta":
+        return load_device
+    return model_device
+
+
+def load_nvfp4_model_weights(
+    model: nn.Module,
+    state: Dict[str, torch.Tensor],
+    compute_dtype: torch.dtype,
+    load_device: torch.device,
+    debug: Optional[Any] = None,
+) -> Tuple[nn.Module, int]:
+    layer_device = _resolve_layer_device(model, load_device)
+    replacements = replace_linear_with_mixed_precision(model, compute_dtype, layer_device)
+    if debug is not None:
+        debug.log(
+            f"Replaced {replacements} Linear layers for NVFP4 loading on {layer_device}",
+            category="dit",
+            force=True,
+        )
+    model.load_state_dict(state, strict=False, assign=True)
+    model._seedvr2_nvfp4 = True
+    return model, replacements


### PR DESCRIPTION
## Summary

Minimal NVFP4 checkpoint loading for SeedVR2 (~200 lines), implemented as a small patch on top of ComfyUI's existing `mixed_precision_ops` / `comfy_quant` stack rather than a standalone quant pipeline.

**New module:** `src/optimization/nvfp4_loader.py`
- Detect NVFP4 checkpoints (filename, safetensors metadata, `weight_scale_2` / `.comfy_quant` keys)
- Prepare state dict via `comfy.utils.convert_old_quants` and inject missing `.comfy_quant` metadata
- Replace `nn.Linear` with `comfy.ops.mixed_precision_ops().Linear` before `load_state_dict(assign=True)`
- Patch linear forward to cast FP32 activations to compute dtype when needed

**Integration:**
- `model_loader.py` — route NVFP4 through the new loader; skip quant metadata keys during dtype conversion
- `compatibility.py` — add `is_nvfp4_model`, improve dtype detection (skip uint8 quant params), FP32→compute_dtype activation handling + autocast in forward

No new dependencies. Falls back cleanly when ComfyUI quant support is unavailable.

**Tested on:** NVIDIA RTX 5070 Ti (Blackwell) with Comfy-Org NVFP4 weights:
https://huggingface.co/Comfy-Org/SeedVR2/tree/main/diffusion_models

Verified models:
- `seedvr2_3b_nvfp4.safetensors`
- `seedvr2_7b_nvfp4.safetensors`
- `seedvr2_7b_sharp_nvfp4.safetensors`

## Test plan

- [x] Load `seedvr2_3b_nvfp4.safetensors` on RTX 5070 Ti (Blackwell)
- [x] Load `seedvr2_7b_nvfp4.safetensors` on RTX 5070 Ti (Blackwell)
- [x] Load `seedvr2_7b_sharp_nvfp4.safetensors` on RTX 5070 Ti (Blackwell)
- [x] End-to-end upscale inference completes without dtype / shape errors
- [ ] FP16 / FP8 / GGUF loading unchanged (regression)
- [ ] Non-Blackwell GPU without NVFP4 compute support (graceful fallback or clear error)